### PR TITLE
update documentation to 7.2.2 iOS

### DIFF
--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -1,5 +1,11 @@
 # MobileID SDK - Release Notes
 
+## 7.2.2
+
+### Improvements
+
+- Updated Sentry SDK to version 8.33.
+
 ## 7.2.1
 
 ### Improvements


### PR DESCRIPTION
Release iOS v7.2.2 - fix sentry compatibility issue with xcode16