### PR TITLE
TRAVELERID-14673 - Fix missing/incorrect iOS documentation

### DIFF
--- a/docs/Features/DocumentReader/DocumentReader_Index.md
+++ b/docs/Features/DocumentReader/DocumentReader_Index.md
@@ -29,50 +29,36 @@ mobile device over the travel e-Document in order to perform a RFID scan to extr
 
 === "iOS"
 
-    To use this feature, you must provide the DocumentReaderConfig to your preferred Provider like the
-    following example:
+    Since version 9, the Document Reader is built on a **provider model**. Instead of a single,
+    Regula-specific configuration, you pick the provider(s) you want to use and pass them to the
+    Enrolment initialization. Each provider has its own setup and is supplied through the
+    `documentScanProvider` (OCR/MRZ) and `documentRFIDProvider` (RFID/NFC) parameters of
+    `Enrolment.shared.initWith(...)`.
+
+    The available providers are:
+
+    - **Amadeus DocScanMrz** (`AMADocScanMrziOS`) — OCR/MRZ document scanning.
+    - **Regula** (`AMADocScanRegulaiOS`) — OCR/MRZ document scanning and RFID reading.
+    - **Amadeus Doc RFID Read** (`AMADocRfid`) — RFID/NFC chip reading.
+
+    Any scan provider can be used as long as it conforms to `DocumentReaderScanProtocol`, and any RFID
+    provider as long as it conforms to `DocumentReaderRFIDProtocol`. You can combine providers (for
+    example, scan with DocScanMrz and read RFID with Amadeus Doc RFID Read).
 
     ``` swift
-    var provider = RegulaDocumentReaderScan(config: documentReaderConfig)
+    Enrolment.shared.initWith(
+        enrolmentConfig: enrolmentConfig,
+        documentScanProvider: documentScanProvider,   // any DocumentReaderScanProtocol
+        documentRFIDProvider: documentRFIDProvider,    // any DocumentReaderRFIDProtocol, or nil
+        ultralightProvider: nil,
+        viewRegister: nil,
+        completionHandler: completionHandler
+    )
     ```
 
-    The DocumentReaderConfig has the following structure:
-
-    ``` swift
-    public struct DocumentReaderConfig {
-        public let multipageProcessing: Bool
-        public let databaseID: String
-        public let databasePath: String?
-        public let scannerTimeout: TimeInterval
-        public let checkHologram: Bool
-        public let scenario: DocumentReaderScenario
-        
-        public init(multipageProcessing: Bool, databaseID: String, databasePath: String? = nil, scannerTimeout: TimeInterval = 30, checkHologram: Bool = false, scenario: DocumentReaderScenario = .ocr)
-    }
-    
-    public enum DocumentReaderScenario: CaseIterable {
-        case ocr
-        case mrz
-    
-        public var value: String {
-            switch self {
-            case .ocr:
-                return "RGL_SCENARIO_OCR"
-            case .mrz:
-                return "RGL_SCENARIO_MRZ"
-            }
-        }
-    }
-    ```
-
-    - multipageProcessing: controls the workflow for documents that might need to have different pages
-    scanned;
-    - databaseId: specify database Id to be used with the document reader functionality (provided by
-    Regula);
-    - databasePath: Database path for .dat file to initialize Regula documents database. Default value is `nil`.
-    - scannerTimeout: Document scan timeout, in seconds. Default value is `30` seconds.
-    - checkHologram: Indicates whether or not the document reader supports Hologram Reading
-    - scenario: Changes the scanning scenario in which the document is captured
+    Each provider has its own import steps, configuration and instantiation. See the
+    [Custom Providers](DocumentReader_Providers.md) page for the per-provider details on how to import
+    and build each one.
     
 ## Initiate Scan
 

--- a/docs/Features/DocumentReader/DocumentReader_Index.md
+++ b/docs/Features/DocumentReader/DocumentReader_Index.md
@@ -30,7 +30,7 @@ mobile device over the travel e-Document in order to perform a RFID scan to extr
 === "iOS"
 
     Since version 9, the Document Reader is built on a **provider model**. Instead of a single,
-    Regula-specific configuration, you pick the provider(s) you want to use and pass them to the
+    fixed configuration, you pick the provider(s) you want to use and pass them to the
     Enrolment initialization. Each provider has its own setup and is supplied through the
     `documentScanProvider` (OCR/MRZ) and `documentRFIDProvider` (RFID/NFC) parameters of
     `Enrolment.shared.initWith(...)`.
@@ -38,7 +38,6 @@ mobile device over the travel e-Document in order to perform a RFID scan to extr
     The available providers are:
 
     - **Amadeus DocScanMrz** (`AMADocScanMrziOS`) — OCR/MRZ document scanning.
-    - **Regula** (`AMADocScanRegulaiOS`) — OCR/MRZ document scanning and RFID reading.
     - **Amadeus Doc RFID Read** (`AMADocRfid`) — RFID/NFC chip reading.
 
     Any scan provider can be used as long as it conforms to `DocumentReaderScanProtocol`, and any RFID

--- a/docs/Features/DocumentReader/DocumentReader_Providers.md
+++ b/docs/Features/DocumentReader/DocumentReader_Providers.md
@@ -17,157 +17,29 @@ This provider uses Regula services and supports both OCR Document Reading and RF
     Work in progress...
 
 === "iOS"
-    
-	### Install using Xcode
-	
-	1.  Open your project in **Xcode**.
-	
-	2.  Navigate to **File ▸ Add Packages…**
-	
-	3.  In the dialog that appears, enter the package repository URL for the SDK you want to add:
-	
-	    **AMADocScanRegulaiOS**
-	
-	        https://github.com/vbmobile/AMADocScanRegulaiOS
-	
-	4.  Select the version to integrate. For new projects, we recommend using the latest available release (for example: **`{{ versions.ios_doc_scan_regula_provider }}`**).
-	
-	5.  Choose the project and target to which the package should be added.
-	
-	6.  Click **Add Package**.
-	
-	Once completed, Xcode will download the package and resolve all required dependencies automatically.
-	
-	***
-	
-	### Install Using `Package.swift`
-	
-	If you manage dependencies manually, add the SDKs to your `Package.swift` file.
-	
-	#### 1. Add the dependency
-	
-	```swift
-	dependencies: [
-	    .package(
-	        url: "https://github.com/vbmobile/AMADocScanRegulaiOS",
-	        exact: "{{ versions.ios_doc_scan_regula_provider }}"
-	    )
-	]
-	```
-	
-	> Replace `{{ versions.ios_doc_scan_regula_provider }}` with the intended version you wish to use.
-	
-	***
-	
-	#### 2. Link the product to your target
-	
-	```swift
-	.target(
-	    name: "YourAppTarget",
-	    dependencies: [
-	        .product(name: "AMADocScanRegulaiOS", package: "AMADocScanRegulaiOS")
-	    ]
-	)
-	```
-	
-	> Replace `YourAppTarget` with the intended target you wish to use.
+
+    Work in progress...
 
 ### How to Instantiate: 
 
 === "Android"
 
     Work in progress...
-    
+
 === "iOS"
-    
-    Creates a `DocumentReaderScanProtocol` using `AMADocScanRegulaiOS ` provider
-    
-    ```swift
-    func amaDocScanRegulaiOSProviderSetup() {
-        var enrolmentConfig: EnrolmentConfig! // Not relevant for this example
 
-        func amaDocScanRegulaiOS() -> DocumentReaderScanProtocol {
-            guard
-                let licensePath = Bundle.main.path(
-                    forResource: "<YOUR_REGULA_LICENCE_FILE>",
-                    ofType: "license"
-                ),
-                (try? Data(contentsOf: URL(fileURLWithPath: licensePath))) != nil
-            else {
-                fatalError("Unable to read Regula License")
-            }
-            let documentReaderConfig: mdi_mob_sdk_doc_mrz_regula_ios.DocumentReaderConfig = DocumentReaderConfig(
-                multipageProcessing: false, // Single-page scanning
-                databaseID: "<YOUR_DATA_BASE_ID>", // Database id
-                scenario: .mrz // MRZ scanning scenario
-            )
-            return RegulaDocumentReaderScan(config: documentReaderConfig)
-        }
+    Work in progress...
 
-        Enrolment.shared.initWith(enrolmentConfig: enrolmentConfig,
-                                  documentScanProvider: amaDocScanRegulaiOS(),
-                                  documentRFIDProvider: nil, // Not relevant for this example
-                                  ultralightProvider: nil, // Not relevant for this example
-                                  viewRegister: nil,
-                                  completionHandler: { result in
-                                      switch result {
-                                      case .success:
-                                          print("SDK is ready to use")
-
-                                      case let .failure(error):
-                                          print("Failure: \(error)")
-                                      }
-                                  })
-    }
-	```
-    
-    
 ### How to Use:
 
 === "Android"
 
     Work in progress...
-    
+
 === "iOS"
 
-	```swift
-     func readDocumentSampleUsage() {
-         // The view controller responsible for presenting the document scanner camera interface
-         var viewController: UIViewController!
-         
-         Enrolment.shared.readDocument(
-            parameters: .init(readRFID: false),
-             viewController: viewController
-         ) { result in
-             switch result {
-             case let .success(report):
-                 print("Document Read: Success!")
-                 print(report)
-                 print(report.idDocument)
-                 print(report.documentStatuses)
-             case let .failure(error):
-                 print(error.featureError.description)
-             }
-         }
-     }
-	```
+    Work in progress...
 
-    Once both providers are initialized, simply pass them as parameters to the Enrolment initialization as shown below. For more information on initializing, see [Enrolment](../../index.md#how-to-initialize-the-sdk).
-
-    ``` swift
-    var documentReaderConfig = DocumentReaderConfig(multipageProcessing: false, databaseID: "Passports", checkHologram: false)
-    
-    var regulaDocumentReaderScan = RegulaDocumentReaderScan(config: documentReaderConfig)
-    var regulaDocumentReaderRFID = RegulaDocumentReaderRFID()
-    
-    Enrolment.shared.initWith(enrolmentConfig: enrolmentConfig,
-                              documentScanProvider: regulaDocumentReaderScan,
-                              documentRFIDProvider: regulaDocumentReaderRFID,
-                              viewRegister: viewRegister,
-                              completionHandler: completionHandler)
-    
-    ```
-    
 ## Amadeus DocScanMrz Provider
 
 This provider uses Amadeus services and supports MRZ Document Reading functionalities.
@@ -393,7 +265,7 @@ This provider uses Amadeus services and supports RFID scanning functionalities.
 	
 	3.  In the dialog that appears, enter the package repository URL for the SDK you want to add:
 	
-	    **AMADocScanRegulaiOS**
+	    **AMADocRfid**
 	
 	        https://github.com/vbmobile/AMADocRfid
 	

--- a/docs/Features/NameMatch/NameMatch_Index.md
+++ b/docs/Features/NameMatch/NameMatch_Index.md
@@ -52,7 +52,46 @@ This strategy might be one of these two options:
 
 === "iOS"
 
-    Work in progress...
+    ```swift
+    /// Compares a reference name against a provided name using ICAO Doc 9303
+    /// MRZ character transliteration rules.
+    ///
+    /// This method does not require SDK initialization.
+    ///
+    /// - Parameters:
+    ///   - reference: The name from the reference document (e.g. passport MRZ).
+    ///   - compare:   The name to compare against the reference.
+    ///   - strategy:  ``NameMatchStrategy/exact`` or ``NameMatchStrategy/approximate``.
+    /// - Returns: `true` if names match according to the chosen strategy.
+    func matchNames(
+        reference: Name,
+        compare: Name,
+        strategy: NameMatchStrategy
+    ) -> Bool
+
+    /// Represents a person's name with first and last name components.
+    public struct Name: Equatable, Hashable, Sendable {
+
+        /// The given/first name(s).
+        public let firstName: String
+
+        /// The family/last name(s).
+        public let lastName: String
+
+        public init(firstName: String, lastName: String)
+    }
+
+    /// Comparison strategy for name matching.
+    public enum NameMatchStrategy: Sendable {
+
+        /// Both names must be exactly equal after ICAO Doc 9303 sanitization.
+        case exact
+
+        /// The reference name must contain the comparison name after ICAO Doc 9303
+        /// sanitization, for both first and last names.
+        case approximate
+    }
+    ```
 
 
 ## Usage example
@@ -82,4 +121,23 @@ This strategy might be one of these two options:
 
 === "iOS"
 
-    Work in progress...
+    ```swift
+    let referenceName = Name(
+        firstName: "JOHN",
+        lastName: "DOE"
+    )
+    let compareName = Name(
+        firstName: "JOHN",
+        lastName: "DOE"
+    )
+    let isExactMatch = Enrolment.shared.matchNames(
+        reference: referenceName,
+        compare: compareName,
+        strategy: .exact
+    )
+    let isApproximateMatch = Enrolment.shared.matchNames(
+        reference: referenceName,
+        compare: compareName,
+        strategy: .approximate
+    )
+    ```

--- a/docs/Features/SubjectManagement/SubjectManagement_Index.md
+++ b/docs/Features/SubjectManagement/SubjectManagement_Index.md
@@ -156,7 +156,6 @@ data you can create the `BuildSubjectParameters` object. This object has the fol
 
     ``` swift 
     public struct BuildSubjectParameters {
-        public let documentData: DocumentData?
         public let idDocument: IdDocument?
         public let documentDataValidated: Bool
         public let documentImage: UIImage
@@ -167,7 +166,6 @@ data you can create the `BuildSubjectParameters` object. This object has the fol
         public let documentReaderReport: DocumentReaderReport?
 
         public init(
-            documentData: DocumentData? = nil,
             idDocument: IdDocument? = nil,
             documentImage: UIImage,
             enrolmentImage: UIImage,

--- a/docs/MigrationGuide/MigrationGuide_iOS.md
+++ b/docs/MigrationGuide/MigrationGuide_iOS.md
@@ -1,11 +1,18 @@
 # Migration Guide
 
+## From 9.1.0 to 9.2.0
+- The `Ultralight` share signature changed from `func share(passengers:) async -> (result: Bool?, error: FeatureError?)` to `func share(passengers:completionHandler:)`. Update your call to use the completion handler instead of `await`.
+
+## From 9.0.0 to 9.1.0
+#### Required Changes
+- `DocumentData` was removed from the `DocumentReaderReport`. You need to replace your data using the `IdDocument` from the `DocumentReaderReport`, which contains the same data as `DocumentData`.
+
 ## From 8.0.0 to 9.0.0
 #### Required Changes
 - Replace old provider dependency with v9 provider dependency. Check the updated [Document Reader Providers](../Features/DocumentReader/DocumentReader_Providers.md) page for more details on the new providers.
-- Update provider initialization to the new model.
-- Update Enrolment.initialize call to the new parameter set. Check the updated [Getting Started](../index.md) page for more details.
-- 
+- Update provider initialization to the new model. The Document Reader is now provider-based: you pick a scan provider (`AMADocScanMrziOS` or `AMADocScanRegulaiOS`) and, optionally, an RFID provider (`AMADocRfid` or Regula's `RegulaDocumentReaderRFID`).
+- Update the `Enrolment.shared.initWith(...)` call to the new parameter set, passing your chosen `documentScanProvider` and `documentRFIDProvider`. Check the updated [Getting Started](../index.md) page for more details.
+
 ## From 7.2.0 to 8.0.0
 #### Required Changes
 - Developers are now required to specify the provider for the orz/mrz and rfid features. Check the updated [Getting Started](../index.md) page

--- a/docs/MigrationGuide/MigrationGuide_iOS.md
+++ b/docs/MigrationGuide/MigrationGuide_iOS.md
@@ -10,7 +10,7 @@
 ## From 8.0.0 to 9.0.0
 #### Required Changes
 - Replace old provider dependency with v9 provider dependency. Check the updated [Document Reader Providers](../Features/DocumentReader/DocumentReader_Providers.md) page for more details on the new providers.
-- Update provider initialization to the new model. The Document Reader is now provider-based: you pick a scan provider (`AMADocScanMrziOS` or `AMADocScanRegulaiOS`) and, optionally, an RFID provider (`AMADocRfid` or Regula's `RegulaDocumentReaderRFID`).
+- Update provider initialization to the new model. The Document Reader is now provider-based: you pick a scan provider (`AMADocScanMrziOS`) and, optionally, an RFID provider (`AMADocRfid`).
 - Update the `Enrolment.shared.initWith(...)` call to the new parameter set, passing your chosen `documentScanProvider` and `documentRFIDProvider`. Check the updated [Getting Started](../index.md) page for more details.
 
 ## From 7.2.0 to 8.0.0

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -8,6 +8,14 @@
 - Funtion `func share(passengers: [AMADocModeliOS.Passenger]) async -> (result: Bool?, error: FeatureError?)` is now `func share(passengers: [AMADocModeliOS.Passenger], completionHandler: @escaping (Bool, FeatureError?) -> Void)`
 
 
+## 9.1.0
+
+### What's new
+
+- Added support for the new RFID reader provider.
+- Removed DocumentData from the Document Reader feature. Use the `IdDocument` from the `DocumentReaderReport`, which contains the same data as `DocumentData`.
+- Added the Name Match feature, allowing a names comparison between a candidate and a reference using `Enrolment.shared.matchNames(reference:compare:strategy:)`. See [Name Match section](../Features/NameMatch/NameMatch_Index.md).
+
 ## 9.0.0
 
 ### What's new

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,9 +83,9 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 	
 	        https://github.com/vbmobile/AMADocScanMrziOS
 	
-	    **AMADocScanRegulaiOS** (Optional Provider)
+	    **AMADocRfid** (Optional Provider)
 	
-	        https://github.com/vbmobile/AMADocScanRegulaiOS
+	        https://github.com/vbmobile/AMADocRfid
 	
 	4.  Select the version to integrate.  
 	    For new projects, we recommend using the latest available release.
@@ -133,7 +133,7 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 
 	***
 	
-	> Repeat the process for `AmaShareUltralight`, `AMADocScanMrziOS` and `AMADocScanRegulaiOS`
+	> Repeat the process for `AmaShareUltralight`, `AMADocScanMrziOS` and `AMADocRfid`
 	
 	Once added, the Enrolment SDK APIs (and any integrated optional modules such as Ultralight or Document Scanning providers) become available to your application through the standard Enrolment SDK integration flow.
 
@@ -227,35 +227,10 @@ The SDK also allows client apps to use their own custom views for its functional
 	import UIKit
 	import AMADocModeliOS
 	import AMADocScanMrziOS
-	import AMADocScanRegulaiOS
+	import AMADocRFIDReadiOS
 	
 	enum DocumentScanProviderSampleBuilder {
 	
-	    /// Creates a document scanner backed by the Regula SDK.
-	    /// Uses MRZ-based scanning scenarios.
-	    static func amaDocScanRegulaiOS() -> DocumentReaderScanProtocol {
-	        /// Ensures the Regula license file exists and is readable
-	        guard
-	            let licensePath = Bundle.main.path(
-	                forResource: "<YOUR_REGULA_LICENCE_FILE>",
-	                ofType: nil
-	            ),
-	            (try? Data(contentsOf: URL(fileURLWithPath: licensePath))) != nil
-	        else {
-	            fatalError("Unable to read Regula License")
-	        }
-	
-	        /// Regula document reader configuration
-	        let documentReaderConfig = DocumentReaderConfig(
-	            multipageProcessing: false, // Single-page scanning
-	            databaseID: "<YOUR_DATA_BASE_ID>", // Database id
-	            scenario: .mrz // MRZ scanning scenario
-	        )
-	
-	        /// Returns a Regula-based document scanner
-	        return RegulaDocumentReaderScan(config: documentReaderConfig)
-	    }
-		
 	    /// Creates a document scanner backed by the PSS provider.
 	    static func amaDocScanMrziOS() -> DocumentReaderScanProtocol {
 	        /// Specifies the expected document type (e.g. passport)
@@ -294,22 +269,18 @@ The SDK also allows client apps to use their own custom views for its functional
     let ultralightProvider: AMAShareUltralight.Ultralight = .init()
     ultralightProvider.initialiseBeamSync(apiKey: "YOUR KEY")
 
-    /// Document scanner based on Regula SDK (MRZ / OCR scanning)
-    let documentScanProviderA: DocumentReaderScanProtocol =
-        DocumentScanProviderSampleBuilder.amaDocScanRegulaiOS()
-
-    /// Document scanner based on Amadeus PSS provider
-    let documentScanProviderB: DocumentReaderScanProtocol =
+    /// Document scanner based on the Amadeus DocScanMrz provider
+    let documentScanProvider: DocumentReaderScanProtocol =
         DocumentScanProviderSampleBuilder.amaDocScanMrziOS()
 
-    let documentScanProvider: DocumentReaderScanProtocol = Bool.random()
-        ? documentScanProviderA // Can be any provider, as long as it complies with DocumentReaderScanProtocol
-        : documentScanProviderB // Can be any provider, as long as it complies with DocumentReaderScanProtocol
-    
+    /// RFID reader based on the Amadeus Doc RFID Read provider
+    let documentRFIDProvider: DocumentReaderRFIDProtocol =
+        AMADocRFIDRead(config: DocRfidReadConfig(apiConfig: apiConfig, enableLogs: true))
+
     Enrolment.shared.initWith(
         enrolmentConfig: enrolmentConfig,
-        documentScanProvider: documentScanProvider, // Any, as long as it complies with DocumentReaderScanProtocol
-        documentRFIDProvider: RegulaDocumentReaderRFID(),
+        documentScanProvider: documentScanProvider, // Any provider conforming to DocumentReaderScanProtocol
+        documentRFIDProvider: documentRFIDProvider, // Any provider conforming to DocumentReaderRFIDProtocol, or nil
         ultralightProvider: ultralightProvider, // Any, as long as it complies with UltralightProtocol
         viewRegister: EnrolmentViewRegister(),
         completionHandler: { result in

--- a/docs/index.md
+++ b/docs/index.md
@@ -968,7 +968,7 @@ In order for the SDK to use the camera, the user must grant permission to do so.
 
 	| Name                   | Version    | Repository                                                |
 	| ---------------------- | ---------- | --------------------------------------------------------- |
-	| AMADocModeliOS         | 1.0.0-rc24 | <https://github.com/vbmobile/AMADocModeliOS>              |
+	| AMADocModeliOS         | 2.0.2      | <https://github.com/vbmobile/AMADocModeliOS>              |
 	| CwlCatchException      | 2.2.1      | <https://github.com/mattgallagher/CwlCatchException>      |
 	| CwlPreconditionTesting | 2.2.2      | <https://github.com/mattgallagher/CwlPreconditionTesting> |
 	| Lottie (SPM)           | 4.4.1      | <https://github.com/airbnb/lottie-spm>                    |

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -3,10 +3,10 @@ VERSIONS = {
     "android_doc_scan_mrz_provider": "2.0.x",
     "android_doc_rfid_read_provider": "2.0.x",
     "android_ultralight_provider": "2.0.x",
-    "ios_enrolment_sdk": "2.0.2",
+    "ios_enrolment_sdk": "9.2.0",
     "ios_doc_scan_regula_provider": "2.0.2",
-    "ios_doc_scan_mrz_provider": "2.0.2",
-    "ios_doc_rfid_read_provider": "2.0.1",
+    "ios_doc_scan_mrz_provider": "2.0.3",
+    "ios_doc_rfid_read_provider": "2.0.2",
     "ios_ultralight_provider": "2.0.4",
 }
 


### PR DESCRIPTION
- Filled in the two empty Name Match tabs with the real API and a quick usage example.
- Rewrote the Document Reader "Configure" section, which was still showing the old v8 Regula-only setup, to match the v9 provider model (scan vs RFID providers and the new `initWith` parameters, with a link over to the Custom Providers page).
- Removed the leftover `DocumentData` bits now that `IdDocument` has replaced it — the stale field in `BuildSubjectParameters` and the old deprecated note.
- Refreshed the dependency and version numbers that had drifted (AMADocModeliOS and the `docs_macros.py` versions).
- Added the 9.1.0 release notes that were missing, plus migration guides for 9.0 → 9.1 and 9.1 → 9.2.
