### PR TITLE
Back-sync release/9.2 into main (TRAVELERID-14157)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /site
 /venv/
 /update-plans/
+/.claude/
+AGENTS.MD
+CLAUDE.MD

--- a/docs/Features/BiometricMatch/BiometricMatch_HandleErrors.md
+++ b/docs/Features/BiometricMatch/BiometricMatch_HandleErrors.md
@@ -35,4 +35,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/BoardingPass/BoardingPass_HandleErrors.md
+++ b/docs/Features/BoardingPass/BoardingPass_HandleErrors.md
@@ -38,4 +38,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/BoardingPass/BoardingPass_Index.md
+++ b/docs/Features/BoardingPass/BoardingPass_Index.md
@@ -64,8 +64,36 @@ The BoardingPassScanParameters has the following structure:
     }
     ```  
 
-The **validate** flag should be set to true if you want the SDK to
-validate the boarding pass data. 
+The **validate** flag controls validation of parsed Bar-Coded Boarding Pass (BCBP)
+data.
+
+When set to `true`, the SDK validates parsed 2D BCBP data against IATA BCBP field
+constraints. Validation runs after a successful barcode parse. If any validation check
+fails, the operation returns a boarding pass invalid error instead of a `BoardingPass`.
+
+The validation checks the following values when they are present in the BCBP payload:
+
+- Header values: format code (`M`), encoded number of legs (`1` to `4`), and electronic
+  ticket indicator (`E` or `L`).
+- Version and passenger values: version prefix (`>`), version number (`6` or `7`),
+  passenger description (`0` to `7`), check-in source, and boarding pass issuance source.
+- Issuer and security values: issue date as a Julian day (`001` to `366`), document type
+  (`B` or `I`), airline designator length (`2` or `3` characters), numeric baggage-tag
+  fields, and security-data prefix (`^`).
+- Per-leg values: carrier designator lengths (`2` or `3` characters), flight date as a
+  Julian day (`001` to `366`), passenger status (`0` to `9`), selectee indicator (`0`,
+  `1`, or `3`), international document verification indicator (`0` to `2`), ID/AD
+  indicator (`0` to `9` or `A` to `F`), free baggage allowance (`K`, `L`, or `PC`), and
+  fast-track indicator (`Y` or `N`).
+
+This validation does not verify an airline, booking, passenger identity, barcode
+signature, or flight status.
+
+!!! warning
+    Keep this value set to `false` unless your integration requires rejecting BCBP data
+    that does not meet these checks. Not all airlines issue 2D boarding pass payloads
+    that comply with IATA BCBP field constraints, so setting it to `true` can reject
+    otherwise usable boarding passes.
 
 If you want to use your own boarding pass scanner, you can also provide the raw result of the scan and pass it to the facade’s parser method. It will return the
 BoardingPass object. The raw result must be passed to the BoardingPassData, which has to be included

--- a/docs/Features/BoardingPass/BoardingPass_PreviewView.md
+++ b/docs/Features/BoardingPass/BoardingPass_PreviewView.md
@@ -12,5 +12,11 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Boarding Pass result example](BoardingPass_Index.md#handle-result)
-    and present the returned boarding pass in your own preview view.
+    Build the preview from the boarding pass returned by `scanBoardingPass`:
+
+    ```swift
+    private func showPreview(for boardingPass: BoardingPassSummary) {
+        passengerNameLabel.text = boardingPass.passengerName
+        boardingPassTypeLabel.text = boardingPass.type
+    }
+    ```

--- a/docs/Features/BoardingPass/BoardingPass_PreviewView.md
+++ b/docs/Features/BoardingPass/BoardingPass_PreviewView.md
@@ -12,4 +12,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Boarding Pass result example](BoardingPass_Index.md#handle-result)
+    and present the returned boarding pass in your own preview view.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -89,94 +89,94 @@ The FeatureError has the following structure:
 
 Here you can find a list of all the error codes the SDK sends to the client application:
 
-| Name                            | Value | Feature           |
-|---------------------------------|-------|-------------------|
-| InvalidApiKey                   | 010   | Configuration     |
-| InvalidEndpoint                 | 011   | Configuration     |
-| InitFailed                      | 012   | Configuration     |
-| NotReady                        | 013   | Configuration     |
-| NotReady                        | 014   | Configuration     |
-| ConfigError                     | 100   | DocumentReader    |
-| NotReady                        | 101   | DocumentReader    |
-| InitFailed                      | 102   | DocumentReader    |
-| ReportIsNull                    | 103   | DocumentReader    |
-| ErrorCertificate                | 104   | DocumentReader    |
-| InvalidCertificate              | 105   | DocumentReader    |
-| LicenseNotFound                 | 106   | DocumentReader    |
-| PermissionNotGranted            | 107   | DocumentReader    |
-| FetchingResourcesFailed         | 120   | DocumentReader    |
-| TransactionFailed               | 121   | DocumentReader    |
-| InvalidDatabaseState            | 122   | DocumentReader    |
-| ProviderNotFound                | 140   | DocumentReader    |
-| InvalidParameters               | 141   | DocumentReader    |
-| MrzError                        | 150   | DocumentReader    |
-| RegulaError                     | 151   | DocumentReader    |
-| MrzTimeout                      | 152   | DocumentReader    |
-| RFIDError                       | 153   | DocumentReader    |
-| GenericError                    | 170   | DocumentReader    |
-| PAError                         | 171   | DocumentReader    |
-| MRZRFIDMismatch                 | 172   | DocumentReader    |
-| UnknownError                    | 180   | DocumentReader    |
-| ConfigError                     | 200   | BoardingPassScan  |
-| BarcodeUnsupported              | 201   | BoardingPassScan  |
-| PermissionNotGranted            | 202   | BoardingPassScan  |
-| BoardingPassNull                | 203   | BoardingPassScan  |
-| CameraInitFailed                | 204   | BoardingPassScan  |
-| TransactionFailed               | 220   | BoardingPassScan  |
-| CameraPermissionNotGranted      | 230   | BoardingPassScan  |
-| BoardingPassScanFailed          | 250   | BoardingPassScan  |
-| BoardingPassItemParserError     | 251   | BoardingPassScan  |
-| BoardingPassInvalid             | 252   | BoardingPassScan  |
-| BarcodeEmpty                    | 253   | BoardingPassScan  |
-| UnknownError                    | 280   | BoardingPassScan  |
-| ConfigError                     | 300   | BoardingPassParse |
-| BarcodeUnsupported              | 301   | BoardingPassParse |
-| PermissionNotGranted            | 302   | BoardingPassParse |
-| BoardingPassNull                | 303   | BoardingPassParse |
-| TransactionFailed               | 320   | BoardingPassParse |
-| BoardingPassItemParserError     | 350   | BoardingPassParse |
-| BoardingPassInvalid             | 351   | BoardingPassParse |
-| BarcodeEmpty                    | 352   | BoardingPassParse |
-| BoardingPassImageNoBarcodeFound | 353   | BoardingPassParse |
-| BoardingPassImageParseError     | 354   | BoardingPassParse |
-| UnknownError                    | 380   | BoardingPassParse |
-| PermissionNotGranted            | 400   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 401   | FaceCapture       |
-| PermissionNotGranted            | 402   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 403   | FaceCapture       |
-| PermissionNotGranted            | 404   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 405   | FaceCapture       |
-| PermissionNotGranted            | 406   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 407   | FaceCapture       |
-| PermissionNotGranted            | 420   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 422   | FaceCapture       |
-| PermissionNotGranted            | 430   | FaceCapture       |
-| InvalidParameters               | 440   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 450   | FaceCapture       |
-| PermissionNotGranted            | 451   | FaceCapture       |
-| ErrorLoadingImageFromStorage    | 452   | FaceCapture       |
-| UnknownError                    | 480   | FaceCapture       |
-| PermissionNotGranted            | 500   | FaceMatch         |
-| ErrorLoadingImages              | 501   | FaceMatch         |
-| TransactionFailed               | 520   | FaceMatch         |
-| CommunicationError              | 521   | FaceMatch         |
-| MatchFailed                     | 550   | FaceMatch         |
-| DataIntegrityFailed             | 551   | FaceMatch         |
-| UnknownError                    | 580   | FaceMatch         |
-| PermissionNotGranted            | 600   | Subject           |
-| DataError                       | 601   | Subject           |
-| TransactionFailed               | 620   | Subject           |
-| CommunicationError              | 621   | Subject           |
-| SubjectServiceError             | 650   | Subject           |
-| MissingBCBP                     | 651   | Subject           |
-| UnknownError                    | 680   | Subject           |
-| ConfigError                     | 700   | Ultralight        |
-| NotReady                        | 701   | Ultralight        |
-| InitFailed                      | 702   | Ultralight        |
-| BluetoothNotGranted             | 703   | Ultralight        |
-| BluetoothNotEnabled             | 704   | Ultralight        |
-| LocationNotEnabled              | 780   | Ultralight        |
-| UnknownError                    | 705   | Ultralight        |
+| Name                            | Value | Feature           | When thrown                                                                          |
+|---------------------------------|-------|-------------------|--------------------------------------------------------------------------------------|
+| InvalidApiKey                   | 010   | Configuration     | API key provided to `configure()` is invalid                                         |
+| InvalidEndpoint                 | 011   | Configuration     | Endpoint URL does not use HTTPS                                                      |
+| InitFailed                      | 012   | Configuration     | SDK fails to fetch configurations from the server                                    |
+| NotReady                        | 013   | Configuration     | SDK feature called before `initialize()` completes                                   |
+| InvalidLicense                  | 014   | Configuration     | License signature is invalid                                                         |
+| ConfigError                     | 100   | DocumentReader    | Feature configurations are missing                                                   |
+| NotReady                        | 101   | DocumentReader    | Document Reader not initialized; call initialize first                               |
+| InitFailed                      | 102   | DocumentReader    | Error initializing Document Reader                                                   |
+| ReportIsNull                    | 103   | DocumentReader    | Report from preview or RFID scan is null                                             |
+| ErrorCertificate                | 104   | DocumentReader    | CSCA certificates not found or not configured on back office                         |
+| InvalidCertificate              | 105   | DocumentReader    | CSCA certificate file is invalid                                                     |
+| LicenseNotFound                 | 106   | DocumentReader    | License file not found at configured path                                            |
+| PermissionNotGranted            | 107   | DocumentReader    | App lacks required permission for document reading                                   |
+| FetchingResourcesFailed         | 120   | DocumentReader    | Resources endpoint request failed                                                    |
+| TransactionFailed               | 121   | DocumentReader    | Transaction registration failed on server                                            |
+| InvalidDatabaseState            | 122   | DocumentReader    | Database download failed and no local backup available                               |
+| ProviderNotFound                | 140   | DocumentReader    | No document reader provider was configured                                           |
+| InvalidParameters               | 141   | DocumentReader    | Invalid parameter passed by client                                                   |
+| MrzError                        | 150   | DocumentReader    | Error reading MRZ via OCR                                                            |
+| RegulaError                     | 151   | DocumentReader    | Internal Document Reader scan error                                                  |
+| MrzTimeout                      | 152   | DocumentReader    | MRZ scan timed out                                                                   |
+| RFIDError                       | 153   | DocumentReader    | Error during RFID process                                                            |
+| GenericError                    | 170   | DocumentReader    | Scan or RFID succeeded but results were invalid                                      |
+| PAError                         | 171   | DocumentReader    | Passive Authentication failed                                                        |
+| MRZRFIDMismatch                 | 172   | DocumentReader    | MRZ and RFID data do not match                                                       |
+| UnknownError                    | 180   | DocumentReader    | Unmapped internal error                                                              |
+| ConfigError                     | 200   | BoardingPassScan  | Feature configurations are missing                                                   |
+| BarcodeUnsupported              | 201   | BoardingPassScan  | Barcode format is not supported                                                      |
+| PermissionNotGranted            | 202   | BoardingPassScan  | App lacks required permission for boarding pass feature                              |
+| BoardingPassNull                | 203   | BoardingPassScan  | Boarding pass returned from scan is null                                             |
+| CameraInitFailed                | 204   | BoardingPassScan  | Camera failed to initialize                                                          |
+| TransactionFailed               | 220   | BoardingPassScan  | Transaction registration failed on server                                            |
+| CameraPermissionNotGranted      | 230   | BoardingPassScan  | User denied camera permission                                                        |
+| BoardingPassScanFailed          | 250   | BoardingPassScan  | Barcode scanning failed                                                              |
+| BoardingPassItemParserError     | 251   | BoardingPassScan  | Error parsing a field from the scanned boarding pass                                 |
+| BoardingPassInvalid             | 252   | BoardingPassScan  | Scanned barcode is not a valid boarding pass                                         |
+| BarcodeEmpty                    | 253   | BoardingPassScan  | Scanned barcode is empty                                                             |
+| UnknownError                    | 280   | BoardingPassScan  | Unmapped internal error                                                              |
+| ConfigError                     | 300   | BoardingPassParse | Feature configurations are missing                                                   |
+| BarcodeUnsupported              | 301   | BoardingPassParse | Barcode format is not supported                                                      |
+| PermissionNotGranted            | 302   | BoardingPassParse | App lacks required permission for boarding pass feature                              |
+| BoardingPassNull                | 303   | BoardingPassParse | Boarding pass is null                                                                |
+| TransactionFailed               | 320   | BoardingPassParse | Transaction registration failed on server                                            |
+| BoardingPassItemParserError     | 350   | BoardingPassParse | Error parsing a field from the boarding pass                                         |
+| BoardingPassInvalid             | 351   | BoardingPassParse | Boarding pass data is invalid                                                        |
+| BarcodeEmpty                    | 352   | BoardingPassParse | Barcode content is empty                                                             |
+| BoardingPassImageNoBarcodeFound | 353   | BoardingPassParse | No barcode found in provided image                                                   |
+| BoardingPassImageParseError     | 354   | BoardingPassParse | Error occurred while parsing provided image                                          |
+| UnknownError                    | 380   | BoardingPassParse | Unmapped internal error                                                              |
+| PermissionNotGranted            | 400   | FaceCapture       | App lacks required permission for face capture feature                               |
+| ErrorLoadingImageFromStorage    | 401   | FaceCapture       | Failed to load image from internal storage                                           |
+| ImagePathIsNull                 | 402   | FaceCapture       | Image path is null                                                                   |
+| LoadImageFailed                 | 403   | FaceCapture       | Failed to load image from given path                                                 |
+| ProcessReportIsNull             | 404   | FaceCapture       | Face capture process report is null                                                  |
+| CameraInitFailed                | 405   | FaceCapture       | Camera failed to initialize                                                          |
+| CameraPictureError              | 406   | FaceCapture       | Error occurred while taking picture                                                  |
+| ParamsIsNull                    | 407   | FaceCapture       | Face capture configuration parameters are null                                       |
+| TransactionFailed               | 420   | FaceCapture       | Transaction registration failed on server                                            |
+| BiometricLivenessServiceFailed  | 422   | FaceCapture       | Liveness service call failed                                                         |
+| CameraPermissionNotGranted      | 430   | FaceCapture       | User denied camera permission                                                        |
+| InvalidParameters               | 440   | FaceCapture       | Invalid parameter passed by client                                                   |
+| TestFailed                      | 450   | FaceCapture       | Captured image failed quality tests                                                  |
+| LivenessTestsFailed             | 451   | FaceCapture       | Liveness quality tests failed                                                        |
+| FaceCaptureTimeout              | 452   | FaceCapture       | Face capture timed out before a valid image was captured                             |
+| UnknownError                    | 480   | FaceCapture       | Unmapped internal error                                                              |
+| PermissionNotGranted            | 500   | FaceMatch         | App lacks required permission for face match feature                                 |
+| ErrorLoadingImages              | 501   | FaceMatch         | Failed to load images for face match                                                 |
+| TransactionFailed               | 520   | FaceMatch         | Transaction registration failed on server                                            |
+| CommunicationError              | 521   | FaceMatch         | Server communication error during face match                                         |
+| MatchFailed                     | 550   | FaceMatch         | Face match between document and selfie failed                                        |
+| DataIntegrityFailed             | 551   | FaceMatch         | Provided hashes and images do not match                                              |
+| UnknownError                    | 580   | FaceMatch         | Unmapped internal error                                                              |
+| PermissionNotGranted            | 600   | Subject           | App lacks required permission for subject feature                                    |
+| DataError                       | 601   | Subject           | SDK internal error passing subject object                                            |
+| TransactionFailed               | 620   | Subject           | Transaction registration failed on server                                            |
+| CommunicationError              | 621   | Subject           | Server communication error during subject action                                     |
+| SubjectServiceError             | 650   | Subject           | Subject action failed on server; check parameters and endpoint                       |
+| MissingBCBP                     | 651   | Subject           | BCBP is missing and is a mandatory field                                             |
+| UnknownError                    | 680   | Subject           | Unmapped internal error                                                              |
+| ConfigError                     | 700   | Ultralight        | Feature configurations are missing                                                   |
+| NotReady                        | 701   | Ultralight        | Ultralight not initialized; call initialize first                                    |
+| InitFailed                      | 702   | Ultralight        | Initialization failed; check API key                                                 |
+| BluetoothNotGranted             | 703   | Ultralight        | Bluetooth permission denied                                                          |
+| BluetoothNotEnabled             | 704   | Ultralight        | Bluetooth is disabled (Android only)                                                 |
+| LocationNotEnabled              | 705   | Ultralight        | Location is disabled (Android only)                                                  |
+| UnknownError                    | 780   | Ultralight        | Unmapped internal error                                                              |
 
 You can use the result code to provide accurate feedback to the user or use the new property inside **FeatureError**, called **errorType** that classifies the type of error.
 We suggest that errors should be handled by **errorType**.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -280,6 +280,9 @@ Here you can find a list of all the error codes the SDK sends to the client appl
     | NotReady | 701 | Ultralight | Ultralight is used before initialization completes. |
     | InitFailed | 702 | Ultralight | Ultralight initialization fails. |
     | BluetoothNotGranted | 703 | Ultralight | Bluetooth permission is not granted. |
+    | BluetoothNotEnabled | 704 | Ultralight | Bluetooth is disabled. |
+    | BluetoothNotSupported | 705 | Ultralight | Bluetooth is not supported on the device. |
+    | BluetoothUnknowError | 706 | Ultralight | An unspecified Bluetooth error occurs. |
     | Unknown | 780 | Ultralight | An Ultralight error cannot be mapped to a known code. |
 
 

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -89,6 +89,8 @@ The FeatureError has the following structure:
 
 Here you can find a list of all the error codes the SDK sends to the client application:
 
+### Android
+
 | Name                            | Value | Feature           | When thrown                                                                          |
 |---------------------------------|-------|-------------------|--------------------------------------------------------------------------------------|
 | InvalidApiKey                   | 010   | Configuration     | API key provided to `configure()` is invalid                                         |
@@ -177,6 +179,105 @@ Here you can find a list of all the error codes the SDK sends to the client appl
 | BluetoothNotEnabled             | 704   | Ultralight        | Bluetooth is disabled (Android only)                                                 |
 | LocationNotEnabled              | 705   | Ultralight        | Location is disabled (Android only)                                                  |
 | UnknownError                    | 780   | Ultralight        | Unmapped internal error                                                              |
+
+### iOS
+
+| Name | Value | Feature | When thrown |
+|------|-------|---------|-------------|
+| InvalidApiKey | 010 | Configuration | The API key is missing or invalid. |
+| InvalidEndpoint | 011 | Configuration | The endpoint is missing, malformed, or does not use HTTPS. |
+| InitFailed | 012 | Configuration | SDK configuration could not be retrieved or decoded during initialization. |
+| NotReady | 013 | Configuration | An SDK operation is requested before initialization completes successfully. |
+| InvalidLicense | 014 | Configuration | The SDK license token is invalid, expired, incorrectly signed, or issued for another application. |
+| InvalidGatewayConfig | 015 | Configuration | Mobile API Gateway configuration is missing or invalid. |
+| GatewayAuthenticationFailed | 016 | Configuration | Authentication with Mobile API Gateway fails. |
+| ConfigError | 100 | Document Reader | Document Reader configuration is unavailable. |
+| NotReady | 101 | Document Reader | Document Reader is used before its provider is initialized. |
+| InitFailed | 102 | Document Reader | The configured provider fails to initialize. |
+| ReportIsNull | 103 | Document Reader | A document scan or RFID operation completes without a report. |
+| ErrorCertificate | 104 | Document Reader | Required CSCA certificates cannot be loaded. |
+| InvalidCertificate | 105 | Document Reader | A supplied CSCA certificate is invalid. |
+| LicenseNotFound | 106 | Document Reader | The provider license cannot be found. |
+| PermissionNotGranted | 107 | Document Reader | The application is not permitted to use Document Reader. |
+| FetchingResourcesFailed | 120 | Document Reader | Provider resources cannot be downloaded. |
+| TransactionFailed | 121 | Document Reader | Transaction registration fails before document reading. |
+| InvalidDatabaseState | 122 | Document Reader | The provider database cannot be downloaded and no usable local database is available. |
+| ProviderNotFound | 140 | Document Reader | No document reader provider was supplied. |
+| InvalidParameter | 141 | Document Reader | A Document Reader parameter is invalid. |
+| MrzError | 150 | Document Reader | MRZ or OCR processing fails. |
+| RegulaError | 151 | Document Reader | The Regula provider reports a scan error. |
+| MrzTimeout | 152 | Document Reader | MRZ scanning exceeds the configured timeout. |
+| RFIDError | 153 | Document Reader | RFID chip reading or chip-data validation fails. |
+| Repeated | 160 | Document Reader | The user chooses to repeat the document-reading flow. |
+| Unknown | 180 | Document Reader | A Document Reader error cannot be mapped to a known code. |
+| TCNotAccepted | 190 | Document Reader | The user rejects the terms and conditions. |
+| ConfigError | 200 | Boarding Pass Scan | Boarding Pass Scanner configuration is unavailable. |
+| BarcodeUnsupported | 201 | Boarding Pass Scan | The scanned barcode format is unsupported. |
+| PermissionNotGranted | 202 | Boarding Pass Scan | The application is not permitted to use Boarding Pass Scanner. |
+| BoardingPassNull | 203 | Boarding Pass Scan | Scanning completes without boarding-pass data. |
+| CameraInitFailed | 204 | Boarding Pass Scan | The camera cannot be initialized. |
+| TransactionFailed | 220 | Boarding Pass Scan | Transaction registration fails before scanning. |
+| CameraPermissionNotGranted | 230 | Boarding Pass Scan | The user denies camera permission. |
+| BoardingPassScanFailed | 250 | Boarding Pass Scan | Barcode capture fails. |
+| BoardingPassItemParserError | 251 | Boarding Pass Scan | A field in the scanned BCBP payload cannot be parsed. |
+| BoardingPassInvalid | 252 | Boarding Pass Scan | The scanned BCBP payload fails validation. |
+| BarcodeEmpty | 253 | Boarding Pass Scan | The scanned barcode contains no data. |
+| Repeated | 260 | Boarding Pass Scan | The user chooses to repeat the boarding-pass scan. |
+| Unknown | 280 | Boarding Pass Scan | A scan error cannot be mapped to a known code. |
+| TCNotAccepted | 290 | Boarding Pass Scan | The user rejects the terms and conditions. |
+| ConfigError | 300 | Boarding Pass Parse | Boarding Pass Parser configuration is unavailable. |
+| BarcodeUnsupported | 301 | Boarding Pass Parse | The supplied barcode format is unsupported. |
+| PermissionNotGranted | 302 | Boarding Pass Parse | The application is not permitted to use Boarding Pass Parser. |
+| BoardingPassNull | 303 | Boarding Pass Parse | No boarding-pass data is supplied. |
+| TransactionFailed | 320 | Boarding Pass Parse | Transaction registration fails before parsing. |
+| BoardingPassItemParserError | 350 | Boarding Pass Parse | A field in the supplied BCBP payload cannot be parsed. |
+| BoardingPassInvalid | 351 | Boarding Pass Parse | The supplied BCBP payload fails validation. |
+| BarcodeEmpty | 352 | Boarding Pass Parse | The supplied barcode contains no data. |
+| Repeated | 360 | Boarding Pass Parse | The user chooses to repeat the boarding-pass flow. |
+| Unknown | 380 | Boarding Pass Parse | A parser error cannot be mapped to a known code. |
+| TCNotAccepted | 390 | Boarding Pass Parse | The user rejects the terms and conditions. |
+| PermissionNotGranted | 400 | Face Capture | The application is not permitted to use Face Capture. |
+| ErrorLoadingImageFromStorage | 401 | Face Capture | A captured image cannot be loaded from internal storage. |
+| ImagePathIsNull | 402 | Face Capture | Face Capture completes without an image path. |
+| LoadImageFailed | 403 | Face Capture | The image at the returned path cannot be loaded. |
+| ProcessReportIsNull | 404 | Face Capture | Face Capture processing completes without a report. |
+| CameraInitFailed | 405 | Face Capture | The camera cannot be initialized. |
+| CameraPictureError | 406 | Face Capture | The camera fails while taking the picture. |
+| ParamsIsNull | 407 | Face Capture | Required Face Capture parameters are missing. |
+| TransactionFailed | 420 | Face Capture | Transaction registration fails before capture. |
+| CommunicationError | 421 | Face Capture | Communication with a biometric service fails. |
+| BiometricLivenessServiceFailed | 422 | Face Capture | The biometric liveness service rejects or cannot process the capture. |
+| CameraPermissionNotGranted | 430 | Face Capture | The user denies camera permission. |
+| InvalidParameter | 440 | Face Capture | A Face Capture parameter is invalid. |
+| TestFailed | 450 | Face Capture | The captured image fails one or more configured quality tests. |
+| LivenessTestsFailed | 451 | Face Capture | The captured image fails liveness checks. |
+| FaceCaptureTimeout | 452 | Face Capture | No valid face is captured before the configured timeout. |
+| Repeated | 460 | Face Capture | The user chooses to retake the face image. |
+| Unknown | 480 | Face Capture | A Face Capture error cannot be mapped to a known code. |
+| TCNotAccepted | 490 | Face Capture | The user rejects the terms and conditions. |
+| PermissionNotGranted | 500 | Face Match | The application is not permitted to use Face Match. |
+| ErrorLoadingImages | 501 | Face Match | The candidate or reference image cannot be loaded. |
+| TransactionFailed | 520 | Face Match | Transaction registration fails before matching. |
+| CommunicationError | 521 | Face Match | Communication with the biometric matching service fails. |
+| MatchFailed | 550 | Face Match | The candidate face does not match the reference face. |
+| DataIntegrityFailed | 551 | Face Match | Image data does not match its supplied integrity hash. |
+| Repeated | 560 | Face Match | The user chooses to repeat Face Match. |
+| Unknown | 580 | Face Match | A Face Match error cannot be mapped to a known code. |
+| TCNotAccepted | 590 | Face Match | The user rejects the terms and conditions. |
+| PermissionNotGranted | 600 | Subject | The application is not permitted to use Subject Management. |
+| DataError | 601 | Subject | Subject data cannot be built or converted for the requested operation. |
+| TransactionFailed | 620 | Subject | Transaction registration fails before the subject operation. |
+| CommunicationError | 621 | Subject | Communication with the Subject service fails. |
+| SubjectServiceError | 650 | Subject | The Subject service rejects or fails the requested operation. |
+| MissingBCBP | 651 | Subject | A required BCBP is missing from the subject data. |
+| Repeated | 660 | Subject | The user chooses to repeat the subject flow. |
+| Unknown | 680 | Subject | A Subject error cannot be mapped to a known code. |
+| TCNotAccepted | 690 | Subject | The user rejects the terms and conditions. |
+| ConfigError | 700 | Ultralight | Ultralight configuration is missing or invalid. |
+| NotReady | 701 | Ultralight | Ultralight is used before initialization completes. |
+| InitFailed | 702 | Ultralight | Ultralight initialization fails. |
+| BluetoothNotGranted | 703 | Ultralight | Bluetooth permission is not granted. |
+| Unknown | 780 | Ultralight | An Ultralight error cannot be mapped to a known code. |
 
 You can use the result code to provide accurate feedback to the user or use the new property inside **FeatureError**, called **errorType** that classifies the type of error.
 We suggest that errors should be handled by **errorType**.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -68,18 +68,21 @@ The FeatureError has the following structure:
         public let description: String
         public let publicMessage: String
 
-        init(errorType: ErrorType, errorCode: Int, description: String, publicMessage: String, name: String) 
+        public init(errorType: ErrorType, errorCode: Int, description: String, publicMessage: String, name: String) 
     }
     
     public enum ErrorType {
+        case configError
+        case badConfigError
         case internalError
         case communicationError
         case termsAndConditionsRejected
         case userRepeated
         case permissionNotGrantedError
         case scanError
-        case scanTimeout
+        case timeout
         case boardingPassInvalid
+        case documentReaderError
         case faceCaptureError
         case faceMatchError
         case subjectError
@@ -282,9 +285,9 @@ Here you can find a list of all the error codes the SDK sends to the client appl
 You can use the result code to provide accurate feedback to the user or use the new property inside **FeatureError**, called **errorType** that classifies the type of error.
 We suggest that errors should be handled by **errorType**.
 
-Alongside with the error code and description that are useful for logging and tracing, we also provide a publicErrorMessage that is a suggestion of what you can show to the final user as an error message.
+Alongside with the error code and description that are useful for logging and tracing, we also provide a `publicMessage` that is a suggestion of what you can show to the final user as an error message.
 
-The value of publicErrorMessage is filled depending on the error type and you can change the default texts or provide additional translations by overriding these strings:
+The value of `publicMessage` is filled depending on the error type and you can change the default texts or provide additional translations by overriding these strings:
 
 === "Android"
 
@@ -307,8 +310,10 @@ The value of publicErrorMessage is filled depending on the error type and you ca
 === "iOS"
 
     ```swift
-    //configurationError
+    //configError
     Theme.shared.strings.errorsPublicMessages.configError
+    //badConfigError
+    Theme.shared.strings.errorsPublicMessages.badConfigError
     //internalError
     Theme.shared.strings.errorsPublicMessages.internalError
     //communicationError
@@ -321,10 +326,12 @@ The value of publicErrorMessage is filled depending on the error type and you ca
     Theme.shared.strings.errorsPublicMessages.permissionNotGrantedError
     //scanError
     Theme.shared.strings.errorsPublicMessages.scanError
-    //scanTimeout
-    Theme.shared.strings.errorsPublicMessages.scanTimeout
+    //timeout
+    Theme.shared.strings.errorsPublicMessages.timeout
     //boardingPassInvalid
     Theme.shared.strings.errorsPublicMessages.boardingPassInvalid
+    //documentReaderError
+    Theme.shared.strings.errorsPublicMessages.documentReaderError
     //faceCaptureError
     Theme.shared.strings.errorsPublicMessages.faceCaptureError
     //faceMatchError
@@ -346,7 +353,7 @@ This is a brief overview of what each ErrorType corresponds to:
 - When it's an internal error, you have to contact Amadeus and share some stacktrace or way to replicate the bug. It usually means that there is some invalid configuration or missing property from our backoffice.
 - Communication errors are mostly caused by internet connection issues, so trying again can solve the problem, it's recommended to allow the user to re-send the request. It can also mean an invalid url of some sort, so if the problem persists you can contact Amadeus.
 - PermissionNotGrantedError means that the user didn't grant permission to use some part of the hardware that is required, as recommended you should have a rationale to explain why that permission is required and block the user from proceeding until he grants the permission.
-- User repeated and user canceled are not exactly errors, they are just warnings to inform that the user wants to try again or canceled the operation.
+- User repeated is not exactly an error; it indicates that the user wants to try the operation again.
 - Scan error happens when there is an error on document scan or any error with the scan of the boarding pass, this usually requires debugging, so it's recommended to share the stacktrace and communicate to Amadeus.
 - Timeout it means that either the timer of document reader or face capture has reached the end and it wasn't possible to capture the image successfully, you can inform the user of that, suggesting how he should scan the document (on the table, with a high contrast from the table, with the proper angle etc..), or take the selfie in better conditions and let the user try again.
 - Boarding pass invalid means that the scan or parse of the boarding pass was correct but some issues were found. Can be the format that is not supported by us, or simply it's not actually a boarding pass barcode.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -68,7 +68,7 @@ The FeatureError has the following structure:
         public let description: String
         public let publicMessage: String
 
-        public init(errorType: ErrorType, errorCode: Int, description: String, publicMessage: String, name: String) 
+        public init(errorType: ErrorType, errorCode: Int, description: String, publicMessage: String, name: String)
     }
     
     public enum ErrorType {
@@ -249,11 +249,11 @@ Here you can find a list of all the error codes the SDK sends to the client appl
 | ParamsIsNull | 407 | Face Capture | Required Face Capture parameters are missing. |
 | TransactionFailed | 420 | Face Capture | Transaction registration fails before capture. |
 | CommunicationError | 421 | Face Capture | Communication with a biometric service fails. |
-| BiometricLivenessServiceFailed | 422 | Face Capture | The biometric liveness service rejects or cannot process the capture. |
+| BiometricLivenessServiceFailed | 422 | Face Capture | Reserved; this code is not currently returned by the iOS SDK. |
 | CameraPermissionNotGranted | 430 | Face Capture | The user denies camera permission. |
 | InvalidParameter | 440 | Face Capture | A Face Capture parameter is invalid. |
 | TestFailed | 450 | Face Capture | The captured image fails one or more configured quality tests. |
-| LivenessTestsFailed | 451 | Face Capture | The captured image fails liveness checks. |
+| LivenessTestsFailed | 451 | Face Capture | Biometric processing reports one or more failed liveness checks. |
 | FaceCaptureTimeout | 452 | Face Capture | No valid face is captured before the configured timeout. |
 | Repeated | 460 | Face Capture | The user chooses to retake the face image. |
 | Unknown | 480 | Face Capture | A Face Capture error cannot be mapped to a known code. |

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -225,15 +225,15 @@ Here you can find a list of all the error codes the SDK sends to the client appl
 | Repeated | 260 | Boarding Pass Scan | The user chooses to repeat the boarding-pass scan. |
 | Unknown | 280 | Boarding Pass Scan | A scan error cannot be mapped to a known code. |
 | TCNotAccepted | 290 | Boarding Pass Scan | The user rejects the terms and conditions. |
-| ConfigError | 300 | Boarding Pass Parse | Boarding Pass Parser configuration is unavailable. |
-| BarcodeUnsupported | 301 | Boarding Pass Parse | The supplied barcode format is unsupported. |
-| PermissionNotGranted | 302 | Boarding Pass Parse | The application is not permitted to use Boarding Pass Parser. |
-| BoardingPassNull | 303 | Boarding Pass Parse | No boarding-pass data is supplied. |
+| ConfigError | 300 | Boarding Pass Parse | Reserved; raw-barcode configuration failures currently return Boarding Pass Scan code `200`. |
+| BarcodeUnsupported | 301 | Boarding Pass Parse | No supported barcode is found in the supplied image. |
+| PermissionNotGranted | 302 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
+| BoardingPassNull | 303 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
 | TransactionFailed | 320 | Boarding Pass Parse | Transaction registration fails before parsing. |
-| BoardingPassItemParserError | 350 | Boarding Pass Parse | A field in the supplied BCBP payload cannot be parsed. |
-| BoardingPassInvalid | 351 | Boarding Pass Parse | The supplied BCBP payload fails validation. |
-| BarcodeEmpty | 352 | Boarding Pass Parse | The supplied barcode contains no data. |
-| Repeated | 360 | Boarding Pass Parse | The user chooses to repeat the boarding-pass flow. |
+| BoardingPassItemParserError | 350 | Boarding Pass Parse | Reserved; BCBP field parsing failures currently return Boarding Pass Scan code `251`. |
+| BoardingPassInvalid | 351 | Boarding Pass Parse | The supplied image cannot be converted or does not contain usable boarding-pass data. |
+| BarcodeEmpty | 352 | Boarding Pass Parse | Reserved; empty raw barcodes currently return Boarding Pass Scan code `253`. |
+| Repeated | 360 | Boarding Pass Parse | Reserved; parser retries are logged internally and this code is not returned to the application. |
 | Unknown | 380 | Boarding Pass Parse | A parser error cannot be mapped to a known code. |
 | TCNotAccepted | 390 | Boarding Pass Parse | The user rejects the terms and conditions. |
 | PermissionNotGranted | 400 | Face Capture | The application is not permitted to use Face Capture. |

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -92,195 +92,196 @@ The FeatureError has the following structure:
 
 Here you can find a list of all the error codes the SDK sends to the client application:
 
-### Android
+=== "Android"
 
-| Name                            | Value | Feature           | When thrown                                                                          |
-|---------------------------------|-------|-------------------|--------------------------------------------------------------------------------------|
-| InvalidApiKey                   | 010   | Configuration     | API key provided to `configure()` is invalid                                         |
-| InvalidEndpoint                 | 011   | Configuration     | Endpoint URL does not use HTTPS                                                      |
-| InitFailed                      | 012   | Configuration     | SDK fails to fetch configurations from the server                                    |
-| NotReady                        | 013   | Configuration     | SDK feature called before `initialize()` completes                                   |
-| InvalidLicense                  | 014   | Configuration     | License signature is invalid                                                         |
-| ConfigError                     | 100   | DocumentReader    | Feature configurations are missing                                                   |
-| NotReady                        | 101   | DocumentReader    | Document Reader not initialized; call initialize first                               |
-| InitFailed                      | 102   | DocumentReader    | Error initializing Document Reader                                                   |
-| ReportIsNull                    | 103   | DocumentReader    | Report from preview or RFID scan is null                                             |
-| ErrorCertificate                | 104   | DocumentReader    | CSCA certificates not found or not configured on back office                         |
-| InvalidCertificate              | 105   | DocumentReader    | CSCA certificate file is invalid                                                     |
-| LicenseNotFound                 | 106   | DocumentReader    | License file not found at configured path                                            |
-| PermissionNotGranted            | 107   | DocumentReader    | App lacks required permission for document reading                                   |
-| FetchingResourcesFailed         | 120   | DocumentReader    | Resources endpoint request failed                                                    |
-| TransactionFailed               | 121   | DocumentReader    | Transaction registration failed on server                                            |
-| InvalidDatabaseState            | 122   | DocumentReader    | Database download failed and no local backup available                               |
-| ProviderNotFound                | 140   | DocumentReader    | No document reader provider was configured                                           |
-| InvalidParameters               | 141   | DocumentReader    | Invalid parameter passed by client                                                   |
-| MrzError                        | 150   | DocumentReader    | Error reading MRZ via OCR                                                            |
-| RegulaError                     | 151   | DocumentReader    | Internal Document Reader scan error                                                  |
-| MrzTimeout                      | 152   | DocumentReader    | MRZ scan timed out                                                                   |
-| RFIDError                       | 153   | DocumentReader    | Error during RFID process                                                            |
-| GenericError                    | 170   | DocumentReader    | Scan or RFID succeeded but results were invalid                                      |
-| PAError                         | 171   | DocumentReader    | Passive Authentication failed                                                        |
-| MRZRFIDMismatch                 | 172   | DocumentReader    | MRZ and RFID data do not match                                                       |
-| UnknownError                    | 180   | DocumentReader    | Unmapped internal error                                                              |
-| ConfigError                     | 200   | BoardingPassScan  | Feature configurations are missing                                                   |
-| BarcodeUnsupported              | 201   | BoardingPassScan  | Barcode format is not supported                                                      |
-| PermissionNotGranted            | 202   | BoardingPassScan  | App lacks required permission for boarding pass feature                              |
-| BoardingPassNull                | 203   | BoardingPassScan  | Boarding pass returned from scan is null                                             |
-| CameraInitFailed                | 204   | BoardingPassScan  | Camera failed to initialize                                                          |
-| TransactionFailed               | 220   | BoardingPassScan  | Transaction registration failed on server                                            |
-| CameraPermissionNotGranted      | 230   | BoardingPassScan  | User denied camera permission                                                        |
-| BoardingPassScanFailed          | 250   | BoardingPassScan  | Barcode scanning failed                                                              |
-| BoardingPassItemParserError     | 251   | BoardingPassScan  | Error parsing a field from the scanned boarding pass                                 |
-| BoardingPassInvalid             | 252   | BoardingPassScan  | Scanned barcode is not a valid boarding pass                                         |
-| BarcodeEmpty                    | 253   | BoardingPassScan  | Scanned barcode is empty                                                             |
-| UnknownError                    | 280   | BoardingPassScan  | Unmapped internal error                                                              |
-| ConfigError                     | 300   | BoardingPassParse | Feature configurations are missing                                                   |
-| BarcodeUnsupported              | 301   | BoardingPassParse | Barcode format is not supported                                                      |
-| PermissionNotGranted            | 302   | BoardingPassParse | App lacks required permission for boarding pass feature                              |
-| BoardingPassNull                | 303   | BoardingPassParse | Boarding pass is null                                                                |
-| TransactionFailed               | 320   | BoardingPassParse | Transaction registration failed on server                                            |
-| BoardingPassItemParserError     | 350   | BoardingPassParse | Error parsing a field from the boarding pass                                         |
-| BoardingPassInvalid             | 351   | BoardingPassParse | Boarding pass data is invalid                                                        |
-| BarcodeEmpty                    | 352   | BoardingPassParse | Barcode content is empty                                                             |
-| BoardingPassImageNoBarcodeFound | 353   | BoardingPassParse | No barcode found in provided image                                                   |
-| BoardingPassImageParseError     | 354   | BoardingPassParse | Error occurred while parsing provided image                                          |
-| UnknownError                    | 380   | BoardingPassParse | Unmapped internal error                                                              |
-| PermissionNotGranted            | 400   | FaceCapture       | App lacks required permission for face capture feature                               |
-| ErrorLoadingImageFromStorage    | 401   | FaceCapture       | Failed to load image from internal storage                                           |
-| ImagePathIsNull                 | 402   | FaceCapture       | Image path is null                                                                   |
-| LoadImageFailed                 | 403   | FaceCapture       | Failed to load image from given path                                                 |
-| ProcessReportIsNull             | 404   | FaceCapture       | Face capture process report is null                                                  |
-| CameraInitFailed                | 405   | FaceCapture       | Camera failed to initialize                                                          |
-| CameraPictureError              | 406   | FaceCapture       | Error occurred while taking picture                                                  |
-| ParamsIsNull                    | 407   | FaceCapture       | Face capture configuration parameters are null                                       |
-| TransactionFailed               | 420   | FaceCapture       | Transaction registration failed on server                                            |
-| BiometricLivenessServiceFailed  | 422   | FaceCapture       | Liveness service call failed                                                         |
-| CameraPermissionNotGranted      | 430   | FaceCapture       | User denied camera permission                                                        |
-| InvalidParameters               | 440   | FaceCapture       | Invalid parameter passed by client                                                   |
-| TestFailed                      | 450   | FaceCapture       | Captured image failed quality tests                                                  |
-| LivenessTestsFailed             | 451   | FaceCapture       | Liveness quality tests failed                                                        |
-| FaceCaptureTimeout              | 452   | FaceCapture       | Face capture timed out before a valid image was captured                             |
-| UnknownError                    | 480   | FaceCapture       | Unmapped internal error                                                              |
-| PermissionNotGranted            | 500   | FaceMatch         | App lacks required permission for face match feature                                 |
-| ErrorLoadingImages              | 501   | FaceMatch         | Failed to load images for face match                                                 |
-| TransactionFailed               | 520   | FaceMatch         | Transaction registration failed on server                                            |
-| CommunicationError              | 521   | FaceMatch         | Server communication error during face match                                         |
-| MatchFailed                     | 550   | FaceMatch         | Face match between document and selfie failed                                        |
-| DataIntegrityFailed             | 551   | FaceMatch         | Provided hashes and images do not match                                              |
-| UnknownError                    | 580   | FaceMatch         | Unmapped internal error                                                              |
-| PermissionNotGranted            | 600   | Subject           | App lacks required permission for subject feature                                    |
-| DataError                       | 601   | Subject           | SDK internal error passing subject object                                            |
-| TransactionFailed               | 620   | Subject           | Transaction registration failed on server                                            |
-| CommunicationError              | 621   | Subject           | Server communication error during subject action                                     |
-| SubjectServiceError             | 650   | Subject           | Subject action failed on server; check parameters and endpoint                       |
-| MissingBCBP                     | 651   | Subject           | BCBP is missing and is a mandatory field                                             |
-| UnknownError                    | 680   | Subject           | Unmapped internal error                                                              |
-| ConfigError                     | 700   | Ultralight        | Feature configurations are missing                                                   |
-| NotReady                        | 701   | Ultralight        | Ultralight not initialized; call initialize first                                    |
-| InitFailed                      | 702   | Ultralight        | Initialization failed; check API key                                                 |
-| BluetoothNotGranted             | 703   | Ultralight        | Bluetooth permission denied                                                          |
-| BluetoothNotEnabled             | 704   | Ultralight        | Bluetooth is disabled (Android only)                                                 |
-| LocationNotEnabled              | 705   | Ultralight        | Location is disabled (Android only)                                                  |
-| UnknownError                    | 780   | Ultralight        | Unmapped internal error                                                              |
+    | Name                            | Value | Feature           | When thrown                                                                          |
+    |---------------------------------|-------|-------------------|--------------------------------------------------------------------------------------|
+    | InvalidApiKey                   | 010   | Configuration     | API key provided to `configure()` is invalid                                         |
+    | InvalidEndpoint                 | 011   | Configuration     | Endpoint URL does not use HTTPS                                                      |
+    | InitFailed                      | 012   | Configuration     | SDK fails to fetch configurations from the server                                    |
+    | NotReady                        | 013   | Configuration     | SDK feature called before `initialize()` completes                                   |
+    | InvalidLicense                  | 014   | Configuration     | License signature is invalid                                                         |
+    | ConfigError                     | 100   | DocumentReader    | Feature configurations are missing                                                   |
+    | NotReady                        | 101   | DocumentReader    | Document Reader not initialized; call initialize first                               |
+    | InitFailed                      | 102   | DocumentReader    | Error initializing Document Reader                                                   |
+    | ReportIsNull                    | 103   | DocumentReader    | Report from preview or RFID scan is null                                             |
+    | ErrorCertificate                | 104   | DocumentReader    | CSCA certificates not found or not configured on back office                         |
+    | InvalidCertificate              | 105   | DocumentReader    | CSCA certificate file is invalid                                                     |
+    | LicenseNotFound                 | 106   | DocumentReader    | License file not found at configured path                                            |
+    | PermissionNotGranted            | 107   | DocumentReader    | App lacks required permission for document reading                                   |
+    | FetchingResourcesFailed         | 120   | DocumentReader    | Resources endpoint request failed                                                    |
+    | TransactionFailed               | 121   | DocumentReader    | Transaction registration failed on server                                            |
+    | InvalidDatabaseState            | 122   | DocumentReader    | Database download failed and no local backup available                               |
+    | ProviderNotFound                | 140   | DocumentReader    | No document reader provider was configured                                           |
+    | InvalidParameters               | 141   | DocumentReader    | Invalid parameter passed by client                                                   |
+    | MrzError                        | 150   | DocumentReader    | Error reading MRZ via OCR                                                            |
+    | RegulaError                     | 151   | DocumentReader    | Internal Document Reader scan error                                                  |
+    | MrzTimeout                      | 152   | DocumentReader    | MRZ scan timed out                                                                   |
+    | RFIDError                       | 153   | DocumentReader    | Error during RFID process                                                            |
+    | GenericError                    | 170   | DocumentReader    | Scan or RFID succeeded but results were invalid                                      |
+    | PAError                         | 171   | DocumentReader    | Passive Authentication failed                                                        |
+    | MRZRFIDMismatch                 | 172   | DocumentReader    | MRZ and RFID data do not match                                                       |
+    | UnknownError                    | 180   | DocumentReader    | Unmapped internal error                                                              |
+    | ConfigError                     | 200   | BoardingPassScan  | Feature configurations are missing                                                   |
+    | BarcodeUnsupported              | 201   | BoardingPassScan  | Barcode format is not supported                                                      |
+    | PermissionNotGranted            | 202   | BoardingPassScan  | App lacks required permission for boarding pass feature                              |
+    | BoardingPassNull                | 203   | BoardingPassScan  | Boarding pass returned from scan is null                                             |
+    | CameraInitFailed                | 204   | BoardingPassScan  | Camera failed to initialize                                                          |
+    | TransactionFailed               | 220   | BoardingPassScan  | Transaction registration failed on server                                            |
+    | CameraPermissionNotGranted      | 230   | BoardingPassScan  | User denied camera permission                                                        |
+    | BoardingPassScanFailed          | 250   | BoardingPassScan  | Barcode scanning failed                                                              |
+    | BoardingPassItemParserError     | 251   | BoardingPassScan  | Error parsing a field from the scanned boarding pass                                 |
+    | BoardingPassInvalid             | 252   | BoardingPassScan  | Scanned barcode is not a valid boarding pass                                         |
+    | BarcodeEmpty                    | 253   | BoardingPassScan  | Scanned barcode is empty                                                             |
+    | UnknownError                    | 280   | BoardingPassScan  | Unmapped internal error                                                              |
+    | ConfigError                     | 300   | BoardingPassParse | Feature configurations are missing                                                   |
+    | BarcodeUnsupported              | 301   | BoardingPassParse | Barcode format is not supported                                                      |
+    | PermissionNotGranted            | 302   | BoardingPassParse | App lacks required permission for boarding pass feature                              |
+    | BoardingPassNull                | 303   | BoardingPassParse | Boarding pass is null                                                                |
+    | TransactionFailed               | 320   | BoardingPassParse | Transaction registration failed on server                                            |
+    | BoardingPassItemParserError     | 350   | BoardingPassParse | Error parsing a field from the boarding pass                                         |
+    | BoardingPassInvalid             | 351   | BoardingPassParse | Boarding pass data is invalid                                                        |
+    | BarcodeEmpty                    | 352   | BoardingPassParse | Barcode content is empty                                                             |
+    | BoardingPassImageNoBarcodeFound | 353   | BoardingPassParse | No barcode found in provided image                                                   |
+    | BoardingPassImageParseError     | 354   | BoardingPassParse | Error occurred while parsing provided image                                          |
+    | UnknownError                    | 380   | BoardingPassParse | Unmapped internal error                                                              |
+    | PermissionNotGranted            | 400   | FaceCapture       | App lacks required permission for face capture feature                               |
+    | ErrorLoadingImageFromStorage    | 401   | FaceCapture       | Failed to load image from internal storage                                           |
+    | ImagePathIsNull                 | 402   | FaceCapture       | Image path is null                                                                   |
+    | LoadImageFailed                 | 403   | FaceCapture       | Failed to load image from given path                                                 |
+    | ProcessReportIsNull             | 404   | FaceCapture       | Face capture process report is null                                                  |
+    | CameraInitFailed                | 405   | FaceCapture       | Camera failed to initialize                                                          |
+    | CameraPictureError              | 406   | FaceCapture       | Error occurred while taking picture                                                  |
+    | ParamsIsNull                    | 407   | FaceCapture       | Face capture configuration parameters are null                                       |
+    | TransactionFailed               | 420   | FaceCapture       | Transaction registration failed on server                                            |
+    | BiometricLivenessServiceFailed  | 422   | FaceCapture       | Liveness service call failed                                                         |
+    | CameraPermissionNotGranted      | 430   | FaceCapture       | User denied camera permission                                                        |
+    | InvalidParameters               | 440   | FaceCapture       | Invalid parameter passed by client                                                   |
+    | TestFailed                      | 450   | FaceCapture       | Captured image failed quality tests                                                  |
+    | LivenessTestsFailed             | 451   | FaceCapture       | Liveness quality tests failed                                                        |
+    | FaceCaptureTimeout              | 452   | FaceCapture       | Face capture timed out before a valid image was captured                             |
+    | UnknownError                    | 480   | FaceCapture       | Unmapped internal error                                                              |
+    | PermissionNotGranted            | 500   | FaceMatch         | App lacks required permission for face match feature                                 |
+    | ErrorLoadingImages              | 501   | FaceMatch         | Failed to load images for face match                                                 |
+    | TransactionFailed               | 520   | FaceMatch         | Transaction registration failed on server                                            |
+    | CommunicationError              | 521   | FaceMatch         | Server communication error during face match                                         |
+    | MatchFailed                     | 550   | FaceMatch         | Face match between document and selfie failed                                        |
+    | DataIntegrityFailed             | 551   | FaceMatch         | Provided hashes and images do not match                                              |
+    | UnknownError                    | 580   | FaceMatch         | Unmapped internal error                                                              |
+    | PermissionNotGranted            | 600   | Subject           | App lacks required permission for subject feature                                    |
+    | DataError                       | 601   | Subject           | SDK internal error passing subject object                                            |
+    | TransactionFailed               | 620   | Subject           | Transaction registration failed on server                                            |
+    | CommunicationError              | 621   | Subject           | Server communication error during subject action                                     |
+    | SubjectServiceError             | 650   | Subject           | Subject action failed on server; check parameters and endpoint                       |
+    | MissingBCBP                     | 651   | Subject           | BCBP is missing and is a mandatory field                                             |
+    | UnknownError                    | 680   | Subject           | Unmapped internal error                                                              |
+    | ConfigError                     | 700   | Ultralight        | Feature configurations are missing                                                   |
+    | NotReady                        | 701   | Ultralight        | Ultralight not initialized; call initialize first                                    |
+    | InitFailed                      | 702   | Ultralight        | Initialization failed; check API key                                                 |
+    | BluetoothNotGranted             | 703   | Ultralight        | Bluetooth permission denied                                                          |
+    | BluetoothNotEnabled             | 704   | Ultralight        | Bluetooth is disabled (Android only)                                                 |
+    | LocationNotEnabled              | 705   | Ultralight        | Location is disabled (Android only)                                                  |
+    | UnknownError                    | 780   | Ultralight        | Unmapped internal error                                                              |
 
-### iOS
+=== "iOS"
 
-| Name | Value | Feature | When thrown |
-|------|-------|---------|-------------|
-| InvalidApiKey | 010 | Configuration | The API key is missing or invalid. |
-| InvalidEndpoint | 011 | Configuration | The endpoint is missing, malformed, or does not use HTTPS. |
-| InitFailed | 012 | Configuration | SDK configuration could not be retrieved or decoded during initialization. |
-| NotReady | 013 | Configuration | An SDK operation is requested before initialization completes successfully. |
-| InvalidLicense | 014 | Configuration | The SDK license token is invalid, expired, incorrectly signed, or issued for another application. |
-| InvalidGatewayConfig | 015 | Configuration | Mobile API Gateway configuration is missing or invalid. |
-| GatewayAuthenticationFailed | 016 | Configuration | Authentication with Mobile API Gateway fails. |
-| ConfigError | 100 | Document Reader | Document Reader configuration is unavailable. |
-| NotReady | 101 | Document Reader | Document Reader is used before its provider is initialized. |
-| InitFailed | 102 | Document Reader | The configured provider fails to initialize. |
-| ReportIsNull | 103 | Document Reader | A document scan or RFID operation completes without a report. |
-| ErrorCertificate | 104 | Document Reader | Required CSCA certificates cannot be loaded. |
-| InvalidCertificate | 105 | Document Reader | A supplied CSCA certificate is invalid. |
-| LicenseNotFound | 106 | Document Reader | The provider license cannot be found. |
-| PermissionNotGranted | 107 | Document Reader | The application is not permitted to use Document Reader. |
-| FetchingResourcesFailed | 120 | Document Reader | Provider resources cannot be downloaded. |
-| TransactionFailed | 121 | Document Reader | Transaction registration fails before document reading. |
-| InvalidDatabaseState | 122 | Document Reader | The provider database cannot be downloaded and no usable local database is available. |
-| ProviderNotFound | 140 | Document Reader | No document reader provider was supplied. |
-| InvalidParameter | 141 | Document Reader | A Document Reader parameter is invalid. |
-| MrzError | 150 | Document Reader | MRZ or OCR processing fails. |
-| RegulaError | 151 | Document Reader | The Regula provider reports a scan error. |
-| MrzTimeout | 152 | Document Reader | MRZ scanning exceeds the configured timeout. |
-| RFIDError | 153 | Document Reader | RFID chip reading or chip-data validation fails. |
-| Repeated | 160 | Document Reader | The user chooses to repeat the document-reading flow. |
-| Unknown | 180 | Document Reader | A Document Reader error cannot be mapped to a known code. |
-| TCNotAccepted | 190 | Document Reader | The user rejects the terms and conditions. |
-| ConfigError | 200 | Boarding Pass Scan | Boarding Pass Scanner configuration is unavailable. |
-| BarcodeUnsupported | 201 | Boarding Pass Scan | The scanned barcode format is unsupported. |
-| PermissionNotGranted | 202 | Boarding Pass Scan | The application is not permitted to use Boarding Pass Scanner. |
-| BoardingPassNull | 203 | Boarding Pass Scan | Scanning completes without boarding-pass data. |
-| CameraInitFailed | 204 | Boarding Pass Scan | The camera cannot be initialized. |
-| TransactionFailed | 220 | Boarding Pass Scan | Transaction registration fails before scanning. |
-| CameraPermissionNotGranted | 230 | Boarding Pass Scan | The user denies camera permission. |
-| BoardingPassScanFailed | 250 | Boarding Pass Scan | Barcode capture fails. |
-| BoardingPassItemParserError | 251 | Boarding Pass Scan | A field in the scanned BCBP payload cannot be parsed. |
-| BoardingPassInvalid | 252 | Boarding Pass Scan | The scanned BCBP payload fails validation. |
-| BarcodeEmpty | 253 | Boarding Pass Scan | The scanned barcode contains no data. |
-| Repeated | 260 | Boarding Pass Scan | The user chooses to repeat the boarding-pass scan. |
-| Unknown | 280 | Boarding Pass Scan | A scan error cannot be mapped to a known code. |
-| TCNotAccepted | 290 | Boarding Pass Scan | The user rejects the terms and conditions. |
-| ConfigError | 300 | Boarding Pass Parse | Reserved; raw-barcode configuration failures currently return Boarding Pass Scan code `200`. |
-| BarcodeUnsupported | 301 | Boarding Pass Parse | No supported barcode is found in the supplied image. |
-| PermissionNotGranted | 302 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
-| BoardingPassNull | 303 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
-| TransactionFailed | 320 | Boarding Pass Parse | Transaction registration fails before parsing. |
-| BoardingPassItemParserError | 350 | Boarding Pass Parse | Reserved; BCBP field parsing failures currently return Boarding Pass Scan code `251`. |
-| BoardingPassInvalid | 351 | Boarding Pass Parse | The supplied image cannot be converted or does not contain usable boarding-pass data. |
-| BarcodeEmpty | 352 | Boarding Pass Parse | Reserved; empty raw barcodes currently return Boarding Pass Scan code `253`. |
-| Repeated | 360 | Boarding Pass Parse | Reserved; parser retries are logged internally and this code is not returned to the application. |
-| Unknown | 380 | Boarding Pass Parse | A parser error cannot be mapped to a known code. |
-| TCNotAccepted | 390 | Boarding Pass Parse | The user rejects the terms and conditions. |
-| PermissionNotGranted | 400 | Face Capture | The application is not permitted to use Face Capture. |
-| ErrorLoadingImageFromStorage | 401 | Face Capture | A captured image cannot be loaded from internal storage. |
-| ImagePathIsNull | 402 | Face Capture | Face Capture completes without an image path. |
-| LoadImageFailed | 403 | Face Capture | The image at the returned path cannot be loaded. |
-| ProcessReportIsNull | 404 | Face Capture | Face Capture processing completes without a report. |
-| CameraInitFailed | 405 | Face Capture | The camera cannot be initialized. |
-| CameraPictureError | 406 | Face Capture | The camera fails while taking the picture. |
-| ParamsIsNull | 407 | Face Capture | Required Face Capture parameters are missing. |
-| TransactionFailed | 420 | Face Capture | Transaction registration fails before capture. |
-| CommunicationError | 421 | Face Capture | Communication with a biometric service fails. |
-| BiometricLivenessServiceFailed | 422 | Face Capture | Reserved; this code is not currently returned by the iOS SDK. |
-| CameraPermissionNotGranted | 430 | Face Capture | The user denies camera permission. |
-| InvalidParameter | 440 | Face Capture | A Face Capture parameter is invalid. |
-| TestFailed | 450 | Face Capture | The captured image fails one or more configured quality tests. |
-| LivenessTestsFailed | 451 | Face Capture | Biometric processing reports one or more failed liveness checks. |
-| FaceCaptureTimeout | 452 | Face Capture | No valid face is captured before the configured timeout. |
-| Repeated | 460 | Face Capture | The user chooses to retake the face image. |
-| Unknown | 480 | Face Capture | A Face Capture error cannot be mapped to a known code. |
-| TCNotAccepted | 490 | Face Capture | The user rejects the terms and conditions. |
-| PermissionNotGranted | 500 | Face Match | The application is not permitted to use Face Match. |
-| ErrorLoadingImages | 501 | Face Match | The candidate or reference image cannot be loaded. |
-| TransactionFailed | 520 | Face Match | Transaction registration fails before matching. |
-| CommunicationError | 521 | Face Match | Communication with the biometric matching service fails. |
-| MatchFailed | 550 | Face Match | The candidate face does not match the reference face. |
-| DataIntegrityFailed | 551 | Face Match | Image data does not match its supplied integrity hash. |
-| Repeated | 560 | Face Match | The user chooses to repeat Face Match. |
-| Unknown | 580 | Face Match | A Face Match error cannot be mapped to a known code. |
-| TCNotAccepted | 590 | Face Match | The user rejects the terms and conditions. |
-| PermissionNotGranted | 600 | Subject | The application is not permitted to use Subject Management. |
-| DataError | 601 | Subject | Subject data cannot be built or converted for the requested operation. |
-| TransactionFailed | 620 | Subject | Transaction registration fails before the subject operation. |
-| CommunicationError | 621 | Subject | Communication with the Subject service fails. |
-| SubjectServiceError | 650 | Subject | The Subject service rejects or fails the requested operation. |
-| MissingBCBP | 651 | Subject | A required BCBP is missing from the subject data. |
-| Repeated | 660 | Subject | The user chooses to repeat the subject flow. |
-| Unknown | 680 | Subject | A Subject error cannot be mapped to a known code. |
-| TCNotAccepted | 690 | Subject | The user rejects the terms and conditions. |
-| ConfigError | 700 | Ultralight | Ultralight configuration is missing or invalid. |
-| NotReady | 701 | Ultralight | Ultralight is used before initialization completes. |
-| InitFailed | 702 | Ultralight | Ultralight initialization fails. |
-| BluetoothNotGranted | 703 | Ultralight | Bluetooth permission is not granted. |
-| Unknown | 780 | Ultralight | An Ultralight error cannot be mapped to a known code. |
+    | Name | Value | Feature | When thrown |
+    |------|-------|---------|-------------|
+    | InvalidApiKey | 010 | Configuration | The API key is missing or invalid. |
+    | InvalidEndpoint | 011 | Configuration | The endpoint is missing, malformed, or does not use HTTPS. |
+    | InitFailed | 012 | Configuration | SDK configuration could not be retrieved or decoded during initialization. |
+    | NotReady | 013 | Configuration | An SDK operation is requested before initialization completes successfully. |
+    | InvalidLicense | 014 | Configuration | The SDK license token is invalid, expired, incorrectly signed, or issued for another application. |
+    | InvalidGatewayConfig | 015 | Configuration | Mobile API Gateway configuration is missing or invalid. |
+    | GatewayAuthenticationFailed | 016 | Configuration | Authentication with Mobile API Gateway fails. |
+    | ConfigError | 100 | Document Reader | Document Reader configuration is unavailable. |
+    | NotReady | 101 | Document Reader | Document Reader is used before its provider is initialized. |
+    | InitFailed | 102 | Document Reader | The configured provider fails to initialize. |
+    | ReportIsNull | 103 | Document Reader | A document scan or RFID operation completes without a report. |
+    | ErrorCertificate | 104 | Document Reader | Required CSCA certificates cannot be loaded. |
+    | InvalidCertificate | 105 | Document Reader | A supplied CSCA certificate is invalid. |
+    | LicenseNotFound | 106 | Document Reader | The provider license cannot be found. |
+    | PermissionNotGranted | 107 | Document Reader | The application is not permitted to use Document Reader. |
+    | FetchingResourcesFailed | 120 | Document Reader | Provider resources cannot be downloaded. |
+    | TransactionFailed | 121 | Document Reader | Transaction registration fails before document reading. |
+    | InvalidDatabaseState | 122 | Document Reader | The provider database cannot be downloaded and no usable local database is available. |
+    | ProviderNotFound | 140 | Document Reader | No document reader provider was supplied. |
+    | InvalidParameter | 141 | Document Reader | A Document Reader parameter is invalid. |
+    | MrzError | 150 | Document Reader | MRZ or OCR processing fails. |
+    | RegulaError | 151 | Document Reader | The Regula provider reports a scan error. |
+    | MrzTimeout | 152 | Document Reader | MRZ scanning exceeds the configured timeout. |
+    | RFIDError | 153 | Document Reader | RFID chip reading or chip-data validation fails. |
+    | Repeated | 160 | Document Reader | The user chooses to repeat the document-reading flow. |
+    | Unknown | 180 | Document Reader | A Document Reader error cannot be mapped to a known code. |
+    | TCNotAccepted | 190 | Document Reader | The user rejects the terms and conditions. |
+    | ConfigError | 200 | Boarding Pass Scan | Boarding Pass Scanner configuration is unavailable. |
+    | BarcodeUnsupported | 201 | Boarding Pass Scan | The scanned barcode format is unsupported. |
+    | PermissionNotGranted | 202 | Boarding Pass Scan | The application is not permitted to use Boarding Pass Scanner. |
+    | BoardingPassNull | 203 | Boarding Pass Scan | Scanning completes without boarding-pass data. |
+    | CameraInitFailed | 204 | Boarding Pass Scan | The camera cannot be initialized. |
+    | TransactionFailed | 220 | Boarding Pass Scan | Transaction registration fails before scanning. |
+    | CameraPermissionNotGranted | 230 | Boarding Pass Scan | The user denies camera permission. |
+    | BoardingPassScanFailed | 250 | Boarding Pass Scan | Barcode capture fails. |
+    | BoardingPassItemParserError | 251 | Boarding Pass Scan | A field in the scanned BCBP payload cannot be parsed. |
+    | BoardingPassInvalid | 252 | Boarding Pass Scan | The scanned BCBP payload fails validation. |
+    | BarcodeEmpty | 253 | Boarding Pass Scan | The scanned barcode contains no data. |
+    | Repeated | 260 | Boarding Pass Scan | The user chooses to repeat the boarding-pass scan. |
+    | Unknown | 280 | Boarding Pass Scan | A scan error cannot be mapped to a known code. |
+    | TCNotAccepted | 290 | Boarding Pass Scan | The user rejects the terms and conditions. |
+    | ConfigError | 300 | Boarding Pass Parse | Reserved; raw-barcode configuration failures currently return Boarding Pass Scan code `200`. |
+    | BarcodeUnsupported | 301 | Boarding Pass Parse | No supported barcode is found in the supplied image. |
+    | PermissionNotGranted | 302 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
+    | BoardingPassNull | 303 | Boarding Pass Parse | Reserved; this code is not currently returned by the iOS parser. |
+    | TransactionFailed | 320 | Boarding Pass Parse | Transaction registration fails before parsing. |
+    | BoardingPassItemParserError | 350 | Boarding Pass Parse | Reserved; BCBP field parsing failures currently return Boarding Pass Scan code `251`. |
+    | BoardingPassInvalid | 351 | Boarding Pass Parse | The supplied image cannot be converted or does not contain usable boarding-pass data. |
+    | BarcodeEmpty | 352 | Boarding Pass Parse | Reserved; empty raw barcodes currently return Boarding Pass Scan code `253`. |
+    | Repeated | 360 | Boarding Pass Parse | Reserved; parser retries are logged internally and this code is not returned to the application. |
+    | Unknown | 380 | Boarding Pass Parse | A parser error cannot be mapped to a known code. |
+    | TCNotAccepted | 390 | Boarding Pass Parse | The user rejects the terms and conditions. |
+    | PermissionNotGranted | 400 | Face Capture | The application is not permitted to use Face Capture. |
+    | ErrorLoadingImageFromStorage | 401 | Face Capture | A captured image cannot be loaded from internal storage. |
+    | ImagePathIsNull | 402 | Face Capture | Face Capture completes without an image path. |
+    | LoadImageFailed | 403 | Face Capture | The image at the returned path cannot be loaded. |
+    | ProcessReportIsNull | 404 | Face Capture | Face Capture processing completes without a report. |
+    | CameraInitFailed | 405 | Face Capture | The camera cannot be initialized. |
+    | CameraPictureError | 406 | Face Capture | The camera fails while taking the picture. |
+    | ParamsIsNull | 407 | Face Capture | Required Face Capture parameters are missing. |
+    | TransactionFailed | 420 | Face Capture | Transaction registration fails before capture. |
+    | CommunicationError | 421 | Face Capture | Communication with a biometric service fails. |
+    | BiometricLivenessServiceFailed | 422 | Face Capture | Reserved; this code is not currently returned by the iOS SDK. |
+    | CameraPermissionNotGranted | 430 | Face Capture | The user denies camera permission. |
+    | InvalidParameter | 440 | Face Capture | A Face Capture parameter is invalid. |
+    | TestFailed | 450 | Face Capture | The captured image fails one or more configured quality tests. |
+    | LivenessTestsFailed | 451 | Face Capture | Biometric processing reports one or more failed liveness checks. |
+    | FaceCaptureTimeout | 452 | Face Capture | No valid face is captured before the configured timeout. |
+    | Repeated | 460 | Face Capture | The user chooses to retake the face image. |
+    | Unknown | 480 | Face Capture | A Face Capture error cannot be mapped to a known code. |
+    | TCNotAccepted | 490 | Face Capture | The user rejects the terms and conditions. |
+    | PermissionNotGranted | 500 | Face Match | The application is not permitted to use Face Match. |
+    | ErrorLoadingImages | 501 | Face Match | The candidate or reference image cannot be loaded. |
+    | TransactionFailed | 520 | Face Match | Transaction registration fails before matching. |
+    | CommunicationError | 521 | Face Match | Communication with the biometric matching service fails. |
+    | MatchFailed | 550 | Face Match | The candidate face does not match the reference face. |
+    | DataIntegrityFailed | 551 | Face Match | Image data does not match its supplied integrity hash. |
+    | Repeated | 560 | Face Match | The user chooses to repeat Face Match. |
+    | Unknown | 580 | Face Match | A Face Match error cannot be mapped to a known code. |
+    | TCNotAccepted | 590 | Face Match | The user rejects the terms and conditions. |
+    | PermissionNotGranted | 600 | Subject | The application is not permitted to use Subject Management. |
+    | DataError | 601 | Subject | Subject data cannot be built or converted for the requested operation. |
+    | TransactionFailed | 620 | Subject | Transaction registration fails before the subject operation. |
+    | CommunicationError | 621 | Subject | Communication with the Subject service fails. |
+    | SubjectServiceError | 650 | Subject | The Subject service rejects or fails the requested operation. |
+    | MissingBCBP | 651 | Subject | A required BCBP is missing from the subject data. |
+    | Repeated | 660 | Subject | The user chooses to repeat the subject flow. |
+    | Unknown | 680 | Subject | A Subject error cannot be mapped to a known code. |
+    | TCNotAccepted | 690 | Subject | The user rejects the terms and conditions. |
+    | ConfigError | 700 | Ultralight | Ultralight configuration is missing or invalid. |
+    | NotReady | 701 | Ultralight | Ultralight is used before initialization completes. |
+    | InitFailed | 702 | Ultralight | Ultralight initialization fails. |
+    | BluetoothNotGranted | 703 | Ultralight | Bluetooth permission is not granted. |
+    | Unknown | 780 | Ultralight | An Ultralight error cannot be mapped to a known code. |
+
 
 You can use the result code to provide accurate feedback to the user or use the new property inside **FeatureError**, called **errorType** that classifies the type of error.
 We suggest that errors should be handled by **errorType**.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -341,6 +341,26 @@ When you call one of our facade methods, then you will need to pass a completion
 
 **You can check more details how to obtain the FeatureError object on the "Handle result" section of the overview page of each feature.**
 
+### iOS error-handling example
+
+Feature-specific errors expose a `featureError` property. Handle its `errorType`
+to decide whether to retry, explain a missing permission, or end the flow:
+
+```swift
+private func handleError(_ error: FeatureError) {
+    switch error.errorType {
+    case .userRepeated:
+        retry()
+    case .permissionNotGrantedError:
+        showPermissionRationale()
+    case .communicationError, .scanError, .timeout:
+        showError(message: error.publicMessage, canRetry: true)
+    default:
+        showError(message: error.publicMessage, canRetry: false)
+    }
+}
+```
+
 This is a brief overview of what each ErrorType corresponds to:
 
 - When it's an internal error, you have to contact Amadeus and share some stacktrace or way to replicate the bug. It usually means that there is some invalid configuration or missing property from our backoffice.

--- a/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
+++ b/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
@@ -38,4 +38,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
+++ b/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
@@ -38,4 +38,6 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).
+    Example can be found here: [DocumentReaderHandleErrors](https://github.com/vbmobile/mobileid-ios-sample/tree/main/Sample%20App/ViewControllers/DocumentReaderViewController.swift)
+
+    See also the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -12,4 +12,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Document Reader result example](DocumentReader_Index.md#handle-result)
+    and present the returned report in your own preview view.

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -16,7 +16,8 @@ To add a preview feature to your app you can follow the example from our sample 
 
     ```swift
     private func showPreview(for report: DocumentReaderReport) {
-        documentImageView.image = report.idDocument.docImageUIImage
-        holderImageView.image = report.idDocument.holderImageUIImage
+        documentImageView.image = report.idDocument.data?.docImageUIImage
+        holderImageView.image = report.idDocument.rfid?.holderImageUIImage
+            ?? report.idDocument.data?.holderImageUIImage
     }
     ```

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -12,5 +12,11 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Document Reader result example](DocumentReader_Index.md#handle-result)
-    and present the returned report in your own preview view.
+    Build the preview from the report returned by `readDocument`:
+
+    ```swift
+    private func showPreview(for report: DocumentReaderReport) {
+        documentImageView.image = report.idDocument.docImageUIImage
+        holderImageView.image = report.idDocument.holderImageUIImage
+    }
+    ```

--- a/docs/Features/DocumentReader/DocumentReader_Providers.md
+++ b/docs/Features/DocumentReader/DocumentReader_Providers.md
@@ -120,6 +120,7 @@ This provider uses Amadeus services and supports MRZ Document Reading functional
 
     val docScanMrzConfig = DocScanMrzConfig(
         enableLogs = <true>,
+        documentType = DocumentType.PASSPORT,
         docScanMrzKey: <YOUR DOC SCAN MRZ KEY>,
     )
 
@@ -150,7 +151,7 @@ This provider uses Amadeus services and supports MRZ Document Reading functional
         context = context, 
         enrolmentConfig = enrolmentConfig,
         documentReaderProvider = documentReaderProvider,
-        callback = callback
+        enrolmentInitializerCallback = callback
     )
     ```
     
@@ -355,7 +356,7 @@ This provider uses Amadeus services and supports RFID scanning functionalities.
         context = context, 
         enrolmentConfig = enrolmentConfig,
         rfidReaderProvider = documentRfidReaderProvider,
-        callback = callback
+        enrolmentInitializerCallback = callback
     )
     ```
 

--- a/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
+++ b/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
@@ -41,4 +41,6 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).
+    Example can be found here: [FaceCaptureHandleErrors](https://github.com/vbmobile/mobileid-ios-sample/tree/main/Sample%20App/ViewControllers/FaceCaptureViewController.swift)
+
+    See also the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
+++ b/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
@@ -41,4 +41,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/FaceCapture/FaceCapture_Index.md
+++ b/docs/Features/FaceCapture/FaceCapture_Index.md
@@ -1,19 +1,26 @@
 # Face Capture
 
-The Mobile ID SDK provides a functionality that simplifies the process of obtaining a frame for
-biometry checks. To achieve it, we use face detection technology, and capture a frame with the
-user’s face. The live photo is then processed and checked against a liveness algorithm that will try
-to detect specific characteristics of spoofing attempts, returning a score that indicates if the
-person using the app is there or trying to impersonate someone else.
+Face Capture simplifies the process of acquiring a high-quality facial image for biometric
+verification. It uses face detection technology to automatically identify the user's face and
+capture an appropriate frame.
 
-## Initiate Face Capture
+The captured live image is processed and evaluated using a liveness detection algorithm that
+analyzes characteristics associated with presentation attacks (spoofing). The result is a liveness
+score indicating the likelihood that the image was captured from a physically present person rather
+than an impersonation attempt.
 
-The Mobile ID SDK provides a complete set of functionalities that allows capturing and processing
-the user’s facial characteristics, and match them against the travel document’s photo. This helps
-ensuring that the user who is enrolling is the document’s owner. The biometric face capture should
-be the final step before creating a Digital ID in a remote system. If you only need to capture a
-frame with the user’s face for biometric quality validation and check against liveness algorithms,
-you can use the method biometricFaceCapture.
+## Initiating Face Capture
+
+Face Capture provides the functionality required to capture and process the user's facial
+characteristics and compare them with the photograph stored in a travel document. This comparison
+helps verify that the person completing the enrollment process is the legitimate owner of the
+document.
+
+As part of a biometric enrollment workflow, Face Capture is typically performed as the final step
+before creating a digital identity in a remote system.
+
+If only facial image acquisition is required—for example, to perform biometric quality validation
+and liveness checks without document matching—the `biometricFaceCapture` method can be used.
 
 === "Android"
 

--- a/docs/Features/FaceCapture/FaceCapture_PreviewView.md
+++ b/docs/Features/FaceCapture/FaceCapture_PreviewView.md
@@ -21,5 +21,10 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Face Capture result example](FaceCapture_Index.md#handle-result)
-    and present the returned image in your own preview view.
+    Build the preview from the report returned by `biometricFaceCapture`:
+
+    ```swift
+    private func showPreview(for report: BiometricFaceCaptureReport) {
+        previewImageView.image = report.photo
+    }
+    ```

--- a/docs/Features/FaceCapture/FaceCapture_PreviewView.md
+++ b/docs/Features/FaceCapture/FaceCapture_PreviewView.md
@@ -21,4 +21,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Face Capture result example](FaceCapture_Index.md#handle-result)
+    and present the returned image in your own preview view.

--- a/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
+++ b/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
@@ -36,4 +36,6 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).
+    Example can be found here: [SubjectHandleErrors](https://github.com/vbmobile/mobileid-ios-sample/tree/main/Sample%20App/ViewControllers/SubjectViewController.swift)
+
+    See also the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
+++ b/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
@@ -36,4 +36,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -5,8 +5,8 @@ This allows passengers to pass through airport processes without re-scanning the
 
 In the current SDK architecture, Ultralight is integrated through the Enrolment SDK facade.
 You provide your own `UltralightProvider` during initialization, and Enrolment exposes two methods to
-control the sharing lifecycle: `share()` (sets passengers and starts broadcasting, asynchronous via
-`OnShareCompletion` callback) and `stopSharing()`.
+control the sharing lifecycle: `share()` (sets passengers and starts broadcasting, asynchronously
+reporting its result through a completion callback) and `stopSharing()`.
 
 ## Prerequisites
 
@@ -113,9 +113,12 @@ Before integrating Ultralight, ensure you have:
 
 ### Step 1: Create and Initialize UltralightProvider
 
-Before initializing Enrolment, create and configure your `UltralightProvider` instance.
-After `initialiseBeamsync()`, you must call `softStart()`;
-report success and errors through `OnSoftStartCompletion`.
+Before initializing Enrolment, create and configure your `UltralightProvider` instance by calling
+`initialiseBeamsync()` with your API key.
+
+On **Android**, you then call `softStart()` yourself and report success and errors through
+`OnSoftStartCompletion`. On **iOS**, the Enrolment SDK runs the soft start for you during
+initialization, so the provider only needs `initialiseBeamSync(apiKey:)`.
 
 === "Android"
 
@@ -166,7 +169,7 @@ report success and errors through `OnSoftStartCompletion`.
                                   
 ### Step 2: Pass Provider to Enrolment Initialization
 
-Pass the `UltralightProvider` to `Enrolment.initialize()`:
+Pass the `UltralightProvider` when you initialize Enrolment:
 
 === "Android"
 
@@ -210,7 +213,8 @@ Pass the `UltralightProvider` to `Enrolment.initialize()`:
 ## Share Passenger Data
 
 The `share()` method sets the passenger list **and** starts sharing in a single call.
-It is asynchronous — pass an `OnShareCompletion` callback to receive the result.
+It is asynchronous — provide a completion callback to receive the result
+(`OnShareCompletion` on Android, a `(Bool, FeatureError?)` completion handler on iOS).
 
 **Passenger model:**
 
@@ -271,7 +275,7 @@ It is asynchronous — pass an `OnShareCompletion` callback to receive the resul
             if result {
                 // Passengers set and Beamsync started successfully
             } else {
-                // Check error.for details
+                // Check error for details
                 print(error ?? "")
             }
         })
@@ -309,7 +313,7 @@ Stop Beamsync when the flow ends (for example, when leaving the screen or destro
 	}
 	```
 	
-	or call it ha hoc 
+	or call it ad hoc
 	
 	```swift
 	enrolment?.stopSharing()
@@ -475,7 +479,7 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	            if result {
 	                // Passengers set and Beamsync started successfully
 	            } else {
-	                // Check error.for details
+	                // Check error for details
 	                print(error ?? "")
 	            }
 	        })
@@ -508,7 +512,7 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	            if result {
 	                // Passengers set and Beamsync started successfully
 	            } else {
-	                // Check error.for details
+	                // Check error for details
 	                print(error ?? "")
 	            }
 	        })
@@ -518,9 +522,9 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 
 	### Notes
 	
-	- The `UltralightProvider` must be initialized **before** passing it to `Enrolment.initialize()`
-	- Ultralight is **not available** in offline mode (`initializeOffline`)
-	- `share()` is **asynchronous** — results are delivered through the `OnShareCompletion` callback
+	- The `UltralightProvider` must be initialized **before** passing it to `Enrolment.shared.initWith(...)`
+	- Ultralight is **not available** in offline mode (`initOffline`)
+	- `share()` is **asynchronous** — the result is delivered through the `completionHandler` closure
 	- `share()` both sets the passenger data **and** starts Beamsync (there is no separate `startSharing()` step)
-	- The SDK performs pre-flight checks for Bluetooth and Location before starting Beamsync
+	- Beamsync requires Bluetooth permission; `share()` fails with a `bluetoothNotGranted` error if it hasn't been granted
 	- Always call `stopSharing()` when cleaning up (e.g., in `deinit()`)

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -229,6 +229,9 @@ It is asynchronous — provide a completion callback to receive the result
 | `eBagTagId`       | `String?`      | Optional electronic bag tag ID           |
 | `tag`             | `String?`      | Optional custom tag                      |
 
+!!! warning "Selfie image size"
+    Ensure `selfieBase64` is **smaller than 256 KB**. Larger images are rejected.
+
 === "Android"
 
     ```kotlin

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -168,14 +168,12 @@ initialization, so the provider only needs `initialiseBeamSync(apiKey:)`.
 	func ultralightProvider() -> UltralightProtocol? {
 	    let ultralight = AMAShareUltralight.Ultralight()
 	    ultralight.initialize(config: .init(level: .debug))
-	    ultralight.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
 	    return ultralight
 	}
 	```
 
-	Call `initialize(config:)` before `initialiseBeamSync(apiKey:)` when
-	diagnostic logging is needed. Use the appropriate log level for the
-	environment.
+	Call `initialize(config:)` when diagnostic logging is needed. Use the
+	appropriate log level for the environment.
                                   
 ### Step 2: Pass Provider to Enrolment Initialization
 
@@ -460,7 +458,6 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	    func ultralightProvider() -> UltralightProtocol? {
 	        let ultralight = AMAShareUltralight.Ultralight()
 	        ultralight.initialize(config: .init(level: .debug))
-	        ultralight.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
 	        return ultralight
 	    }
 	
@@ -485,7 +482,16 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	    }
 	
 	    func sampleShare(enrolment: EnrolmentProtocol?) {
-	        let passenger = AMAShareUltralight.UltralightBuilders.build(
+	        let passenger1 = Passenger(language: "en",
+	                                  mrz: "<mrz-line-1>\n<mrz-line-2>",
+	                                  boardingPasses: ["<bcbp-barcode-string>"],
+	                                  docPhotoBase64: "<base64-encoded-document-photo>",
+	                                  selfieBase64: "<base64-encoded-selfie>",
+	                                  ePassport: true,
+	                                  tag: nil,
+	                                  ebagtagId: nil)
+
+	        let passenger2 = AMAShareUltralight.UltralightBuilders.build(
 	            paxId: nil, // Defaults to UUID().uuidString
 	            idDocument: nil,
 	            faceCapture: nil,
@@ -493,7 +499,7 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	            language: nil // Defaults to "en"
 	        )
 
-	        enrolment?.share(passengers: [passenger], completionHandler: { result, error in
+	        enrolment?.share(passengers: [passenger1, passenger2], completionHandler: { result, error in
 	            if result {
 	                // Passengers set and Beamsync started successfully
 	            } else {
@@ -508,24 +514,13 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	    }
 	
 	    func prepareAndSharePassenger(enrolment: EnrolmentProtocol?) {
-	        guard EnrolmentData.idDocument != nil else {
-	            print("Precondition failed: Have not read document")
-	            return
-	        }
-	        guard let faceCapture = EnrolmentData.biometricFaceCaptureReport?.photo else {
-	            print("Precondition failed: Have not read face")
-	            return
-	        }
-	        guard EnrolmentData.boardingPass != nil else {
-	            print("Precondition failed: Have not read boarding pass")
-	            return
-	        }
-	        guard let idDocument = EnrolmentData.idDocument else {
-	            print("Precondition failed: idDocument missing")
-	            return
-	        }
-	        let boardPass = EnrolmentData.boardingPass?.raw ?? ""
-	        let passenger = idDocument.mapToPassenger(faceCapture: faceCapture, boardingPasses: [boardPass])
+	        let passenger = AMAShareUltralight.UltralightBuilders.build(
+	            paxId: nil, // Defaults to UUID().uuidString
+	            idDocument: EnrolmentData.idDocument,
+	            faceCapture: EnrolmentData.biometricFaceCaptureReport?.photo,
+	            boardingPass: EnrolmentData.boardingPass?.raw ?? "",
+	            language: nil // Defaults to "en"
+	        )
 	        enrolment?.share(passengers: [passenger], completionHandler: { result, error in
 	            if result {
 	                // Passengers set and Beamsync started successfully

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -230,7 +230,7 @@ It is asynchronous — provide a completion callback to receive the result
 | `tag`             | `String?`      | Optional custom tag                      |
 
 !!! warning "Selfie image size"
-    Ensure `selfieBase64` is **smaller than 256 KB**. Larger images are rejected.
+    Ensure `selfieBase64` and `docPhotoBase64` are **smaller than 256 KB**. Larger images are rejected.
 
 === "Android"
 

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -62,6 +62,8 @@ Before integrating Ultralight, ensure you have:
     }
     ```
 
+    - Target API level 26 (Oreo) or later;
+
 === "iOS"
    
       Ultralight is distributed for iOS via **Swift Package Manager (SPM)**.

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -166,11 +166,16 @@ initialization, so the provider only needs `initialiseBeamSync(apiKey:)`.
 
 	```swift
 	func ultralightProvider() -> UltralightProtocol? {
-	    let ultralightProvider: AMAShareUltralight.Ultralight = .init()
-	    ultralightProvider.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
-	    return ultralightProvider
+	    let ultralight = AMAShareUltralight.Ultralight()
+	    ultralight.initialize(config: .init(level: .debug))
+	    ultralight.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
+	    return ultralight
 	}
 	```
+
+	Call `initialize(config:)` before `initialiseBeamSync(apiKey:)` when
+	diagnostic logging is needed. Use the appropriate log level for the
+	environment.
                                   
 ### Step 2: Pass Provider to Enrolment Initialization
 
@@ -269,16 +274,20 @@ It is asynchronous — provide a completion callback to receive the result
 === "iOS"
 
 
+	Prefer `UltralightBuilders.build(...)` when creating passengers. It
+	normalizes optional values such as the passenger ID and language and keeps
+	passenger construction aligned with the Ultralight provider API.
+
 	```swift
     func sampleShare(enrolment: EnrolmentProtocol?) {
-        let passenger = Passenger(language: "en",
-                                  mrz: "<mrz-line-1>\n<mrz-line-2>",
-                                  boardingPasses: ["<bcbp-barcode-string>"],
-                                  docPhotoBase64: "<base64-encoded-document-photo>",
-                                  selfieBase64: "<base64-encoded-selfie>",
-                                  ePassport: true,
-                                  tag: nil,
-                                  ebagtagId: nil)
+        let passenger = AMAShareUltralight.UltralightBuilders.build(
+            paxId: nil, // Defaults to UUID().uuidString
+            idDocument: nil,
+            faceCapture: nil,
+            boardingPass: "<bcbp-barcode-string>",
+            language: nil // Defaults to "en"
+        )
+
         enrolment?.share(passengers: [passenger], completionHandler: { result, error in
             if result {
                 // Passengers set and Beamsync started successfully
@@ -449,9 +458,10 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	
 	class UltralightProviderSample {
 	    func ultralightProvider() -> UltralightProtocol? {
-	        let ultralightProvider: AMAShareUltralight.Ultralight = .init()
-	        ultralightProvider.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
-	        return ultralightProvider
+	        let ultralight = AMAShareUltralight.Ultralight()
+	        ultralight.initialize(config: .init(level: .debug))
+	        ultralight.initialiseBeamSync(apiKey: "<your-ultralight-api-key>")
+	        return ultralight
 	    }
 	
 	    func initializeEnrolment(provider: UltralightProtocol?) async -> EnrolmentProtocol {
@@ -475,14 +485,14 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
 	    }
 	
 	    func sampleShare(enrolment: EnrolmentProtocol?) {
-	        let passenger = Passenger(language: "en",
-	                                  mrz: "<mrz-line-1>\n<mrz-line-2>",
-	                                  boardingPasses: ["<bcbp-barcode-string>"],
-	                                  docPhotoBase64: "<base64-encoded-document-photo>",
-	                                  selfieBase64: "<base64-encoded-selfie>",
-	                                  ePassport: true,
-	                                  tag: nil,
-	                                  ebagtagId: nil)
+	        let passenger = AMAShareUltralight.UltralightBuilders.build(
+	            paxId: nil, // Defaults to UUID().uuidString
+	            idDocument: nil,
+	            faceCapture: nil,
+	            boardingPass: "<bcbp-barcode-string>",
+	            language: nil // Defaults to "en"
+	        )
+
 	        enrolment?.share(passengers: [passenger], completionHandler: { result, error in
 	            if result {
 	                // Passengers set and Beamsync started successfully

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -131,7 +131,12 @@ initialization, so the provider only needs `initialiseBeamSync(apiKey:)`.
     private fun initializeUltralight(): UltralightProvider? {
         val ultralightApiKey = "<your-ultralight-api-key>"
 
-        UltralightSdk.initialize(context = requireContext())
+        UltralightSdk.initialize(
+            context = requireContext(),
+            config = UltralightConfig(
+                logLevel = UltralightLogLevel.ERROR 
+            )
+        )
         val provider = UltralightSdk.getInstance()
         provider.initialiseBeamsync(ultralightApiKey)
         provider.softStart(requireContext(), object : OnSoftStartCompletion {
@@ -340,7 +345,12 @@ Here's a complete example integrating Ultralight with the Enrolment SDK:
         private fun initializeUltralight(): UltralightProvider? {
             val ultralightApiKey = "<your-api-key>"
 
-            UltralightSdk.initialize(context = requireContext())
+            UltralightSdk.initialize(
+                context = requireContext(),
+                config = UltralightConfig(
+                    logLevel = UltralightLogLevel.ERROR 
+                )
+            )
             val provider = UltralightSdk.getInstance()
             provider.initialiseBeamsync(ultralightApiKey)
             provider.softStart(requireContext(), object : OnSoftStartCompletion {

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -73,11 +73,11 @@ Before integrating Ultralight, ensure you have:
     3. Enter the package repository URL:
    
     ```
-    https://github.com/vbmobile/AmaShareUltralight
+    https://github.com/vbmobile/AMAShareUltralight
     ```
    
     4. Select the desired version (recommended: exact or up to next major)
-    5. Add the **AmaShareUltralight** product to your app target
+    5. Add the **AMAShareUltralight** product to your app target
 
     __Install using `Package.swift`__
    
@@ -86,7 +86,7 @@ Before integrating Ultralight, ensure you have:
     ``` swift
     dependencies: [
        .package(
-           url: "https://github.com/vbmobile/AmaShareUltralight",
+           url: "https://github.com/vbmobile/AMAShareUltralight",
            exact: "{{ versions.ios_ultralight_provider }}"
        )
     ],
@@ -100,10 +100,13 @@ Before integrating Ultralight, ensure you have:
     .target(
         name: "YourAppTarget",
         dependencies: [
-            .product(name: "AmaShareUltralight", package: "AmaShareUltralight")
+            .product(name: "AMAShareUltralight", package: "AMAShareUltralight")
         ]
     )
     ```
+
+    !!! important "Image size limit"
+        The images you provide to `AMAShareUltralight` as `docPhotoBase64` and `selfieBase64` must each be **smaller than 256 KB**. Larger images are rejected.
 
 	> Replace `YourAppTarget ` with the intended app target you wish to use.
 

--- a/docs/Features/Ultralight/Ultralight_Index.md
+++ b/docs/Features/Ultralight/Ultralight_Index.md
@@ -46,6 +46,18 @@ Before integrating Ultralight, ensure you have:
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location is required to detect nearby Bluetooth devices.</string>
 	```
+
+	For Beamsync to continue operating while the app is backgrounded, add these
+	background modes to the application target's `Info.plist`:
+
+	``` xml
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+		<string>bluetooth-peripheral</string>
+		<string>fetch</string>
+	</array>
+	```
         
 ## How to Import
 

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -5,7 +5,11 @@
 ### What's new
 
 - General bug fixes.
-- Funtion `func share(passengers: [AMADocModeliOS.Passenger]) async -> (result: Bool?, error: FeatureError?)` is now `func share(passengers: [AMADocModeliOS.Passenger], completionHandler: @escaping (Bool, FeatureError?) -> Void)`
+- Function `func share(passengers: [AMADocModeliOS.Passenger]) async -> (result: Bool?, error: FeatureError?)` is now `func share(passengers: [AMADocModeliOS.Passenger], completionHandler: @escaping (Bool, FeatureError?) -> Void)`
+
+### Improvements
+
+- Updated the recommended provider versions: DocScanMrz `2.0.3`, Doc RFID Read `2.0.2`, and Ultralight `2.0.4`.
 
 
 ## 9.1.0

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -4,8 +4,15 @@
 
 ### Improvements
 
-- Updated the recommended AMAShareUltralight provider version to `2.0.15`.
-- AMAShareUltralight `2.0.15` uses UltralightFramework `3.3.4`.
+- Updated the recommended DocScanMrz provider version to `2.0.5`.
+- Updated the recommended AMAShareUltralight provider version to `2.0.16`.
+- AMAShareUltralight `2.0.16` uses UltralightFramework `3.3.4`.
+
+### Bug Fixes
+
+- Improved DocScanMrz scanner cleanup and re-initialization behavior.
+- Replaced run-loop-dependent MRZ processing timeouts with cancellable timeouts.
+- Corrected VIZ document-type mapping with a forward-compatible unknown-value fallback.
 
 ## 9.2.1
 

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -1,5 +1,12 @@
 # MobileID SDK - Release Notes
 
+## 9.2.2
+
+### Improvements
+
+- Updated the recommended AMAShareUltralight provider version to `2.0.15`.
+- AMAShareUltralight `2.0.15` uses UltralightFramework `3.3.4`.
+
 ## 9.2.1
 
 ### Improvements

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-- Fixed an issue: TRAVELERID-15227.
+- Fixed on callback user experience during RFID processing.
+
 
 ## 9.2.0
 

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Fixed on callback user experience during RFID processing.
+- Improved callback user experience during RFID processing.
 
 
 ## 9.2.0

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -1,5 +1,15 @@
 # MobileID SDK - Release Notes
 
+## 9.2.1
+
+### Improvements
+
+- Updated the recommended provider version for AMAShareUltralight to `2.0.13`.
+
+### Bug Fixes
+
+- Fixed an issue: TRAVELERID-15227.
+
 ## 9.2.0
 
 ### What's new

--- a/docs/ReleaseNotes/ReleaseNotes_iOS.md
+++ b/docs/ReleaseNotes/ReleaseNotes_iOS.md
@@ -5,8 +5,12 @@
 ### Improvements
 
 - Updated the recommended DocScanMrz provider version to `2.0.5`.
-- Updated the recommended AMAShareUltralight provider version to `2.0.16`.
-- AMAShareUltralight `2.0.16` uses UltralightFramework `3.3.4`.
+- Updated the recommended AMAShareUltralight provider version to `2.0.17`.
+- AMAShareUltralight `2.0.17` uses UltralightFramework `3.3.4`.
+- AMAShareUltralight `2.0.17` supports `arm64` iOS devices and `arm64` plus
+  `x86_64` iOS Simulators.
+- The Swift package uses automatic linkage; consumers must still resolve and
+  package the provider's required binary dependencies.
 
 ### Bug Fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ hide:
     To integrate the Mobile ID SDK for Android, the following prerequisites must be met:
 
     - Install or update Android Studio to latest version;
-    - Target API level 24 (Marshmallow) or later;
+    - Target API level 24 (Marshmallow) or later (no ultralight);
+    - For Ultralight, API level 26 (Orep) or later is needed;
 
 === "iOS"
 
@@ -43,6 +44,9 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
     // Optional dependencies if you want to use the ultralight share feature
     implementation("com.amadeus.mdi.mob.sdk:ama-ultralight:{{ versions.android_ultralight_provider }}")
     ```
+
+    Each separated provider dependency requires **Target API level 24 (Marshmallow) or later**.
+
     3. Add these rules to proguard if you have problems running the application with minify enabled:
     ```kotlin
     -keepclassmembers enum * { *; }

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hide:
 
     - Install or update Android Studio to latest version;
     - Target API level 24 (Marshmallow) or later (no ultralight);
-    - For Ultralight, API level 26 (Orep) or later is needed;
+    - For Ultralight, API level 26 (Oreo) or later is needed;
 
 === "iOS"
 
@@ -56,7 +56,7 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
     implementation("com.amadeus.mdi.mob.sdk:ama-ultralight:{{ versions.android_ultralight_provider }}")
     ```
 
-    Each separated provider dependency requires **Target API level 24 (Marshmallow) or later**.
+    Each separated provider dependency requires **Target API level 24 (Marshmallow) or later but when importing also the Ultralight sdk, the minimum sdk should be 26 (Oreo) or later**.
 
     3. Add these rules to proguard if you have problems running the application with minify enabled:
     ```kotlin
@@ -357,7 +357,7 @@ You can follow this platform specific guide to prepare your application to offli
         context = context, 
         enrolmentConfig = enrolmentConfig,
         documentReaderProvider = documentReaderProvider,
-        rfidReaderProvider = documentReaderProvider,
+        rfidReaderProvider = rfidReaderProvider,
         enrolmentInitializerCallback = callback,
         license = license
     )
@@ -686,7 +686,7 @@ The EnrolmentConfig is where you set the apiConfig and the apiSecurityConfig.
         enrolmentConfig = enrolmentConfig,
         enrolmentCustomViews = enrolmentCustomViews,
         documentReaderProvider = documentReaderProvider,
-        rfidReaderProvider = documentReaderProvider,
+        rfidReaderProvider = rfidReaderProvider,
         enrolmentInitializerCallback = enrolmentInitializerCallback
     )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,8 +91,15 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 	
 	        https://github.com/vbmobile/AMADocRfid
 	
-	4.  Select the version to integrate.  
-	    For new projects, we recommend using the latest available release.
+	4.  Select the component versions to integrate. The following versions are the
+	    supported set for Mobile ID SDK 9.2:
+
+	    | Component | Version |
+	    |-----------|---------|
+	    | `MobileIdSDKiOS` | `{{ versions.ios_enrolment_sdk }}` |
+	    | `AMAShareUltralight` | `{{ versions.ios_ultralight_provider }}` |
+	    | `AMADocScanMrziOS` | `{{ versions.ios_doc_scan_mrz_provider }}` |
+	    | `AMADocRFIDReadiOS` | `{{ versions.ios_doc_rfid_read_provider }}` |
 	
 	5.  Choose the project and target to which the package should be added.
 	

--- a/docs/index.md
+++ b/docs/index.md
@@ -961,7 +961,7 @@ In order for the SDK to use the camera, the user must grant permission to do so.
 
 	| Name                   | Version    | Repository                                                |
 	| ---------------------- | ---------- | --------------------------------------------------------- |
-	| AMADocModeliOS         | 2.0.2      | <https://github.com/vbmobile/AMADocModeliOS>              |
+	| AMADocModeliOS         | 2.0.3      | <https://github.com/vbmobile/AMADocModeliOS>              |
 	| CwlCatchException      | 2.2.1      | <https://github.com/mattgallagher/CwlCatchException>      |
 	| CwlPreconditionTesting | 2.2.2      | <https://github.com/mattgallagher/CwlPreconditionTesting> |
 	| Lottie (SPM)           | 4.4.1      | <https://github.com/airbnb/lottie-spm>                    |

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,17 @@ hide:
     - Install or update Xcode to latest version;
     - Target iOS 15 or later. __The iOS 15 target grows to iOS 18.2 if the provider `AMADocScanMrziOS` is used.__ 
 
+    | Component | Minimum iOS | Physical devices | Apple silicon simulator | Intel simulator |
+    |-----------|-------------|------------------|-------------------------|-----------------|
+    | `MobileIdSDKiOS` | 15 | `arm64` | `arm64` | `x86_64` |
+    | `AMAShareUltralight` | 15 | `arm64` | `arm64` | Not supported |
+    | `AMADocScanMrziOS` | 18.2 | `arm64` | `arm64` | Not supported |
+    | `AMADocRFIDReadiOS` | 15 | `arm64` | `arm64` | `x86_64` |
+
+    Simulator architecture refers to the Mac architecture on which the iOS
+    Simulator runs. Components without an `x86_64` simulator slice require an
+    Apple silicon Mac for simulator builds.
+
 You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can associate the API key with the application, this way your API key is protected with only authorized applications.
 
 ## Enrolment SDK setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,13 +19,13 @@ hide:
     To integrate the **Mobile ID SDK** for iOS, the following prerequisites must be met: 
     
     - Install or update Xcode to latest version;
-    - Target iOS 15 or later. __The iOS 15 target grows to iOS 18.2 if the provider `AMADocScanMrziOS` is used.__ 
+    - Target iOS 15 or later.
 
     | Component | Minimum iOS | Physical devices | Apple silicon simulator | Intel simulator |
     |-----------|-------------|------------------|-------------------------|-----------------|
     | `MobileIdSDKiOS` | 15 | `arm64` | `arm64` | `x86_64` |
     | `AMAShareUltralight` | 15 | `arm64` | `arm64` | Not supported |
-    | `AMADocScanMrziOS` | 18.2 | `arm64` | `arm64` | Not supported |
+    | `AMADocScanMrziOS` | 15 | `arm64` | `arm64` | Not supported |
     | `AMADocRFIDReadiOS` | 15 | `arm64` | `arm64` | `x86_64` |
 
     Simulator architecture refers to the Mac architecture on which the iOS

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ hide:
     | Component | Minimum iOS | Physical devices | Apple silicon simulator | Intel simulator |
     |-----------|-------------|------------------|-------------------------|-----------------|
     | `MobileIdSDKiOS` | 15 | `arm64` | `arm64` | `x86_64` |
-    | `AMAShareUltralight` | 15 | `arm64` | `arm64` | Not supported |
+    | `AMAShareUltralight` | 15 | `arm64` | `arm64` | `x86_64` |
     | `AMADocScanMrziOS` | 15 | `arm64` | `arm64` | Not supported |
     | `AMADocRFIDReadiOS` | 15 | `arm64` | `arm64` | `x86_64` |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 	dependencies: [
 	    .package(
 	        url: "https://github.com/vbmobile/MobileIdSDKiOS",
-	        upToNextMinor(from: "{{ versions.ios_enrolment_sdk }}"
+	        .upToNextMinor(from: "{{ versions.ios_enrolment_sdk }}")
 	    )
 	]
 	```

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,9 +75,9 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 	
 	        https://github.com/vbmobile/MobileIdSDKiOS
 	
-	    **AmaShareUltralight** (Optional Provider)
+	    **AMAShareUltralight** (Optional Provider)
 	
-	        https://github.com/vbmobile/AmaShareUltralight
+	        https://github.com/vbmobile/AMAShareUltralight
 	
 	    **AMADocScanMrziOS** (Optional Provider)
 	
@@ -133,7 +133,7 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 
 	***
 	
-	> Repeat the process for `AmaShareUltralight`, `AMADocScanMrziOS` and `AMADocRfid`
+	> Repeat the process for `AMAShareUltralight`, `AMADocScanMrziOS` and `AMADocRfid`
 	
 	Once added, the Enrolment SDK APIs (and any integrated optional modules such as Ultralight or Document Scanning providers) become available to your application through the standard Enrolment SDK integration flow.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can
 	dependencies: [
 	    .package(
 	        url: "https://github.com/vbmobile/MobileIdSDKiOS",
-	        .upToNextMinor(from: "{{ versions.ios_enrolment_sdk }}")
+	        .exact("{{ versions.ios_enrolment_sdk }}")
 	    )
 	]
 	```

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -1,8 +1,8 @@
 VERSIONS = {
     "android_enrolment_sdk": "9.2.0",
-    "android_doc_scan_mrz_provider": "2.0.3",
-    "android_doc_rfid_read_provider": "2.0.3",
-    "android_ultralight_provider": "2.0.3",
+    "android_doc_scan_mrz_provider": "2.0.5",
+    "android_doc_rfid_read_provider": "2.0.5",
+    "android_ultralight_provider": "2.0.5",
     "ios_enrolment_sdk": "9.2.1",
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.3",

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -3,11 +3,11 @@ VERSIONS = {
     "android_doc_scan_mrz_provider": "2.0.3",
     "android_doc_rfid_read_provider": "2.0.3",
     "android_ultralight_provider": "2.0.3",
-    "ios_enrolment_sdk": "9.2.1",
+    "ios_enrolment_sdk": "9.2.2",
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.3",
     "ios_doc_rfid_read_provider": "2.0.2",
-    "ios_ultralight_provider": "2.0.13",
+    "ios_ultralight_provider": "2.0.15",
 }
 
 def define_env(env):

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -1,8 +1,8 @@
 VERSIONS = {
     "android_enrolment_sdk": "9.2.0",
-    "android_doc_scan_mrz_provider": "2.0.5",
-    "android_doc_rfid_read_provider": "2.0.5",
-    "android_ultralight_provider": "2.0.5",
+    "android_doc_scan_mrz_provider": "2.0.6",
+    "android_doc_rfid_read_provider": "2.0.6",
+    "android_ultralight_provider": "2.0.6",
     "ios_enrolment_sdk": "9.2.2",
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.5",

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -3,11 +3,11 @@ VERSIONS = {
     "android_doc_scan_mrz_provider": "2.0.1",
     "android_doc_rfid_read_provider": "2.0.1",
     "android_ultralight_provider": "2.0.3",
-    "ios_enrolment_sdk": "9.2.0",
+    "ios_enrolment_sdk": "9.2.1",
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.3",
     "ios_doc_rfid_read_provider": "2.0.2",
-    "ios_ultralight_provider": "2.0.4",
+    "ios_ultralight_provider": "2.0.13",
 }
 
 def define_env(env):

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -1,7 +1,7 @@
 VERSIONS = {
     "android_enrolment_sdk": "9.2.0",
-    "android_doc_scan_mrz_provider": "2.0.1",
-    "android_doc_rfid_read_provider": "2.0.1",
+    "android_doc_scan_mrz_provider": "2.0.3",
+    "android_doc_rfid_read_provider": "2.0.3",
     "android_ultralight_provider": "2.0.3",
     "ios_enrolment_sdk": "9.2.0",
     "ios_doc_scan_regula_provider": "2.0.2",

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -5,9 +5,9 @@ VERSIONS = {
     "android_ultralight_provider": "2.0.3",
     "ios_enrolment_sdk": "9.2.2",
     "ios_doc_scan_regula_provider": "2.0.2",
-    "ios_doc_scan_mrz_provider": "2.0.3",
+    "ios_doc_scan_mrz_provider": "2.0.5",
     "ios_doc_rfid_read_provider": "2.0.2",
-    "ios_ultralight_provider": "2.0.15",
+    "ios_ultralight_provider": "2.0.16",
 }
 
 def define_env(env):

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -2,7 +2,7 @@ VERSIONS = {
     "android_enrolment_sdk": "9.2.0",
     "android_doc_scan_mrz_provider": "2.0.1",
     "android_doc_rfid_read_provider": "2.0.1",
-    "android_ultralight_provider": "2.0.1",
+    "android_ultralight_provider": "2.0.3",
     "ios_enrolment_sdk": "9.2.0",
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.3",

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -7,7 +7,7 @@ VERSIONS = {
     "ios_doc_scan_regula_provider": "2.0.2",
     "ios_doc_scan_mrz_provider": "2.0.5",
     "ios_doc_rfid_read_provider": "2.0.2",
-    "ios_ultralight_provider": "2.0.16",
+    "ios_ultralight_provider": "2.0.17",
 }
 
 def define_env(env):


### PR DESCRIPTION
`release/9.2` is ahead of `main` by the TRAVELERID-14157 docs — PR #47 (UltraLight page accuracy fixes + the 9.2.0 release-notes provider-versions line) went straight to `release/9.2` so it would deploy. This back-syncs those into `main` so the default branch isn't left behind.

Net diff is just the two files (`Ultralight_Index.md`, `ReleaseNotes_iOS.md`).