### PR TITLE
TRAVELERID-15224: Document supported iOS architectures

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,17 @@ hide:
     - Install or update Xcode to latest version;
     - Target iOS 15 or later. __The iOS 15 target grows to iOS 18.2 if the provider `AMADocScanMrziOS` is used.__ 
 
+    | Component | Minimum iOS | Physical devices | Apple silicon simulator | Intel simulator |
+    |-----------|-------------|------------------|-------------------------|-----------------|
+    | `MobileIdSDKiOS` | 15 | `arm64` | `arm64` | `x86_64` |
+    | `AMAShareUltralight` | 15 | `arm64` | `arm64` | Not supported |
+    | `AMADocScanMrziOS` | 18.2 | `arm64` | `arm64` | Not supported |
+    | `AMADocRFIDReadiOS` | 15 | `arm64` | `arm64` | `x86_64` |
+
+    Simulator architecture refers to the Mac architecture on which the iOS
+    Simulator runs. Components without an `x86_64` simulator slice require an
+    Apple silicon Mac for simulator builds.
+
 You must also send an ID (Bundle ID or Application ID) to Amadeus so that we can associate the API key with the application, this way your API key is protected with only authorized applications.
 
 ## Enrolment SDK setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,13 +19,13 @@ hide:
     To integrate the **Mobile ID SDK** for iOS, the following prerequisites must be met: 
     
     - Install or update Xcode to latest version;
-    - Target iOS 15 or later. __The iOS 15 target grows to iOS 18.2 if the provider `AMADocScanMrziOS` is used.__ 
+    - Target iOS 15 or later.
 
     | Component | Minimum iOS | Physical devices | Apple silicon simulator | Intel simulator |
     |-----------|-------------|------------------|-------------------------|-----------------|
     | `MobileIdSDKiOS` | 15 | `arm64` | `arm64` | `x86_64` |
     | `AMAShareUltralight` | 15 | `arm64` | `arm64` | Not supported |
-    | `AMADocScanMrziOS` | 18.2 | `arm64` | `arm64` | Not supported |
+    | `AMADocScanMrziOS` | 15 | `arm64` | `arm64` | Not supported |
     | `AMADocRFIDReadiOS` | 15 | `arm64` | `arm64` | `x86_64` |
 
     Simulator architecture refers to the Mac architecture on which the iOS


### PR DESCRIPTION
## Summary
- list device and simulator architectures for every iOS component
- distinguish Apple silicon and Intel simulator support
- include each component’s minimum iOS requirement

## Evidence
Architectures were verified from the published 9.2-compatible XCFramework `Info.plist` metadata.

## Dependency
Stacked on #52 because both tickets update Getting Started.

## Validation
- MkDocs build passes
- rendered architecture table verified in generated output