### PR TITLE
TRAVELERID-15065: Replace private iOS sample links

### DIFF
--- a/docs/Features/BiometricMatch/BiometricMatch_HandleErrors.md
+++ b/docs/Features/BiometricMatch/BiometricMatch_HandleErrors.md
@@ -35,4 +35,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/BoardingPass/BoardingPass_HandleErrors.md
+++ b/docs/Features/BoardingPass/BoardingPass_HandleErrors.md
@@ -38,4 +38,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/BoardingPass/BoardingPass_PreviewView.md
+++ b/docs/Features/BoardingPass/BoardingPass_PreviewView.md
@@ -12,5 +12,11 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Boarding Pass result example](BoardingPass_Index.md#handle-result)
-    and present the returned boarding pass in your own preview view.
+    Build the preview from the boarding pass returned by `scanBoardingPass`:
+
+    ```swift
+    private func showPreview(for boardingPass: BoardingPassSummary) {
+        passengerNameLabel.text = boardingPass.passengerName
+        boardingPassTypeLabel.text = boardingPass.type
+    }
+    ```

--- a/docs/Features/BoardingPass/BoardingPass_PreviewView.md
+++ b/docs/Features/BoardingPass/BoardingPass_PreviewView.md
@@ -12,4 +12,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Boarding Pass result example](BoardingPass_Index.md#handle-result)
+    and present the returned boarding pass in your own preview view.

--- a/docs/Features/Common/HandleErrors.md
+++ b/docs/Features/Common/HandleErrors.md
@@ -341,6 +341,26 @@ When you call one of our facade methods, then you will need to pass a completion
 
 **You can check more details how to obtain the FeatureError object on the "Handle result" section of the overview page of each feature.**
 
+### iOS error-handling example
+
+Feature-specific errors expose a `featureError` property. Handle its `errorType`
+to decide whether to retry, explain a missing permission, or end the flow:
+
+```swift
+private func handleError(_ error: FeatureError) {
+    switch error.errorType {
+    case .userRepeated:
+        retry()
+    case .permissionNotGrantedError:
+        showPermissionRationale()
+    case .communicationError, .scanError, .timeout:
+        showError(message: error.publicMessage, canRetry: true)
+    default:
+        showError(message: error.publicMessage, canRetry: false)
+    }
+}
+```
+
 This is a brief overview of what each ErrorType corresponds to:
 
 - When it's an internal error, you have to contact Amadeus and share some stacktrace or way to replicate the bug. It usually means that there is some invalid configuration or missing property from our backoffice.

--- a/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
+++ b/docs/Features/DocumentReader/DocumentReader_HandleErrors.md
@@ -38,4 +38,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -12,4 +12,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Document Reader result example](DocumentReader_Index.md#handle-result)
+    and present the returned report in your own preview view.

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -16,7 +16,8 @@ To add a preview feature to your app you can follow the example from our sample 
 
     ```swift
     private func showPreview(for report: DocumentReaderReport) {
-        documentImageView.image = report.idDocument.docImageUIImage
-        holderImageView.image = report.idDocument.holderImageUIImage
+        documentImageView.image = report.idDocument.data?.docImageUIImage
+        holderImageView.image = report.idDocument.rfid?.holderImageUIImage
+            ?? report.idDocument.data?.holderImageUIImage
     }
     ```

--- a/docs/Features/DocumentReader/DocumentReader_PreviewView.md
+++ b/docs/Features/DocumentReader/DocumentReader_PreviewView.md
@@ -12,5 +12,11 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Document Reader result example](DocumentReader_Index.md#handle-result)
-    and present the returned report in your own preview view.
+    Build the preview from the report returned by `readDocument`:
+
+    ```swift
+    private func showPreview(for report: DocumentReaderReport) {
+        documentImageView.image = report.idDocument.docImageUIImage
+        holderImageView.image = report.idDocument.holderImageUIImage
+    }
+    ```

--- a/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
+++ b/docs/Features/FaceCapture/FaceCapture_HandleErrors.md
@@ -41,4 +41,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).

--- a/docs/Features/FaceCapture/FaceCapture_PreviewView.md
+++ b/docs/Features/FaceCapture/FaceCapture_PreviewView.md
@@ -21,5 +21,10 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    See the public [Face Capture result example](FaceCapture_Index.md#handle-result)
-    and present the returned image in your own preview view.
+    Build the preview from the report returned by `biometricFaceCapture`:
+
+    ```swift
+    private func showPreview(for report: BiometricFaceCaptureReport) {
+        previewImageView.image = report.photo
+    }
+    ```

--- a/docs/Features/FaceCapture/FaceCapture_PreviewView.md
+++ b/docs/Features/FaceCapture/FaceCapture_PreviewView.md
@@ -21,4 +21,5 @@ To add a preview feature to your app you can follow the example from our sample 
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [Face Capture result example](FaceCapture_Index.md#handle-result)
+    and present the returned image in your own preview view.

--- a/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
+++ b/docs/Features/SubjectManagement/SubjectManagement_HandleErrors.md
@@ -36,4 +36,4 @@ After obtaining the FeatureError, as shown in the Handle Result section of the f
 
 === "iOS"
 
-    Example can be found here: [Sample Project](https://github.com/vbmobile/mobileid-ios-sample-)
+    See the public [iOS error-handling example](../Common/HandleErrors.md#ios-error-handling-example).


### PR DESCRIPTION
## Summary
- replace every malformed/private iOS sample URL in feature error and preview pages
- add a public, rendered iOS error-handling example
- point preview pages to their public feature result examples

## Dependency
Stacked on #54 because both tickets update the common error page.

## Validation
- MkDocs build passes
- no `mobileid-ios-sample-` URLs remain
- all new internal links resolve without MkDocs warnings